### PR TITLE
fix: load provider-path providers via a meta-path finder

### DIFF
--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 import importlib
+import importlib.abc
+import importlib.machinery
 import sys
 from collections.abc import Iterator, Mapping
 from pathlib import Path
@@ -10,7 +12,9 @@ from typing import TYPE_CHECKING, Any, Protocol, Union, runtime_checkable
 from .info import ALL_FIELDS
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Sequence
+    from importlib.machinery import ModuleSpec
+    from types import ModuleType
 
     StrMapping = Mapping[str, Any]
 else:
@@ -53,6 +57,41 @@ DMProtocols = Union[
 ]
 
 
+class _ProviderPathFinder(importlib.abc.MetaPathFinder):
+    """Load the top-level provider module from ``provider-path``.
+
+    Mirrors how pyproject_hooks handles PEP 517 ``backend-path``: a finder at
+    the front of ``sys.meta_path`` guarantees the in-tree provider wins over a
+    same-named module elsewhere on ``sys.path`` (or behind another finder), and
+    a provider absent from ``provider-path`` raises instead of silently
+    importing the wrong module. Only the top-level name is intercepted; nested
+    modules resolve through the parent package's path. A provider already cached
+    in ``sys.modules`` short-circuits import and bypasses this finder.
+    """
+
+    def __init__(self, provider_path: list[str], provider: str) -> None:
+        self.provider_path = provider_path
+        self.provider = provider
+        self.provider_parent = provider.partition(".")[0]
+
+    def find_spec(
+        self,
+        fullname: str,
+        _path: Sequence[str] | None,
+        _target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
+        if "." in fullname:
+            return None
+
+        spec = importlib.machinery.PathFinder.find_spec(
+            fullname, path=self.provider_path
+        )
+        if spec is None and fullname == self.provider_parent:
+            msg = f"Cannot find module {self.provider!r} in {self.provider_path!r}"
+            raise ModuleNotFoundError(msg)
+        return spec
+
+
 def load_provider(
     provider: str,
     provider_path: str | None = None,
@@ -64,11 +103,12 @@ def load_provider(
         msg = "provider-path must be an existing directory"
         raise AssertionError(msg)
 
+    finder = _ProviderPathFinder([provider_path], provider)
+    sys.meta_path.insert(0, finder)
     try:
-        sys.path.insert(0, provider_path)
         return importlib.import_module(provider)
     finally:
-        sys.path.pop(0)
+        sys.meta_path.remove(finder)
 
 
 def load_dynamic_metadata(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,11 +1,39 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 import dynamic_metadata.loader
 import dynamic_metadata.plugins
+
+
+def test_load_provider_path_loads_local(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "local_prov_ok.py").write_text(
+        "def dynamic_metadata(field, settings, project):\n    return '1.2.3'\n"
+    )
+
+    provider = dynamic_metadata.loader.load_provider("local_prov_ok", str(plugin_dir))
+    assert provider.dynamic_metadata("version", {}, {}) == "1.2.3"
+
+
+def test_load_provider_path_not_shadowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A same-named module reachable via the normal sys.path ...
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "shadow_prov.py").write_text("WRONG = True\n")
+    monkeypatch.syspath_prepend(str(other))
+
+    # ... must not satisfy a provider-path request that does not contain it.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(ModuleNotFoundError):
+        dynamic_metadata.loader.load_provider("shadow_prov", str(empty))
 
 
 def test_template_basic() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`load_provider` loaded `provider-path` providers by prepending the directory to `sys.path` and calling `importlib.import_module`. But `importlib` resolves a same-named module already reachable via `sys.path` (or sitting behind another meta-path finder, e.g. an editable install) in preference to the in-tree provider, **silently returning the wrong module**.

This mirrors how `pyproject_hooks` (used by pip and `pypa/build`) loads a PEP 517 `backend-path` backend. Earlier versions of that library also just prepended `sys.path`; current versions insert a dedicated `MetaPathFinder` at the front of `sys.meta_path`, because — quoting their docstring — "the only way to ensure the backend is loaded from the right place is to prepend our own."

The new `_ProviderPathFinder`:
- resolves the **top-level** provider name only against `provider-path` via `PathFinder.find_spec`, so nothing on `sys.path` can shadow it;
- intercepts only the top-level name (`"." in fullname` → defer), so nested modules resolve through the parent package's `__path__`;
- raises `ModuleNotFoundError` when the provider is absent from `provider-path`, instead of importing a foreign same-named module;
- is removed from `sys.meta_path` in a `finally` (we can't rely on process exit the way an out-of-process PEP 517 hook can).

Known caveat, documented in the docstring: a provider already cached in `sys.modules` short-circuits `import_module` and bypasses the finder. `pyproject_hooks` doesn't hit this because every hook runs in a fresh subprocess; in practice scikit-build-core resolves dynamic metadata inside those same hook subprocesses, so the provider is normally imported cold.

## Test plan

- Added `test_load_provider_path_not_shadowed`: a same-named module on `sys.path` must not satisfy a `provider-path` request that lacks it. Confirmed it fails on the old code (`DID NOT RAISE ModuleNotFoundError`) and passes now.
- Added `test_load_provider_path_loads_local` for the happy path.
- Full suite: 14 passed; `prek -a` clean (ruff + mypy `--strict`).

Once this looks right, I'll mirror the same change into scikit-build-core's identical `load_provider` so they don't drift.