### PR TITLE
feat!: redesign plugins as an ordered list of providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@ is still WiP and may change.
 
 The library is split into three audiences (see README.md):
 
-- **Users** configure plugins under `[tool.dynamic-metadata.<field-name>]` with
-  a `provider` (module path) and optional `provider-path` (local dir).
+- **Users** configure plugins as an ordered array of tables,
+  `[[tool.dynamic-metadata]]`, each with a `provider` (module path) and optional
+  `provider-path` (local dir). Entries run in order.
 - **Plugin authors** implement the hooks; they do _not_ need to depend on this
   package at runtime.
 - **Backend authors** consume `loader.py` to drive plugins; they also do not
@@ -44,11 +45,16 @@ warnings as errors and uses `--strict-markers --strict-config`.
 ### The plugin protocol
 
 A plugin is any module exposing
-`dynamic_metadata(field, settings, project) -> value`. Two optional hooks:
-`dynamic_wheel(field, settings) -> bool` (METADATA 2.2 dynamic status; version
-must be false) and `get_requires_for_dynamic_metadata(settings) -> list[str]`
-(extra build requirements). Protocols are defined in `loader.py`
-(`DynamicMetadataProtocol` and subclasses).
+`dynamic_metadata(settings, project, build_state) -> dict[str, Any]`. It returns
+a fragment of the `[project]` table (`{field: value, ...}`), so one plugin may
+set several fields. Two optional hooks:
+`dynamic_wheel(settings) -> dict[str, bool]` (per-field METADATA 2.2 dynamic
+status; version must be false) and
+`get_requires_for_dynamic_metadata(settings) -> list[str]` (extra build
+requirements). Protocols are defined in `loader.py` (`DynamicMetadataProtocol`
+and subclasses). There is no `field` argument: generic plugins (`regex`,
+`template`) read their target from a `field` setting; single-purpose plugins
+hardcode it.
 
 ### Field taxonomy — `info.py`
 
@@ -58,16 +64,19 @@ dynamic and what _shape_ their value has: `STR_FIELDS`, `LIST_STR_FIELDS`,
 `entry-points`, `optional-dependencies`. `name` and `dynamic` are intentionally
 excluded. `ALL_FIELDS` is the union and is what `loader.py` validates against.
 
-### Lazy, ordered resolution — `loader.py`
+### Ordered resolution — `loader.py`
 
-`process_dynamic_metadata(project, metadata)` is the entry point. The key design
-is `DynamicPyProject`, a `Mapping` that resolves providers **lazily on
-`__getitem__`**. This lets one plugin request another field via
-`project["other-field"]`; the dependency is computed on demand and removed from
-`dynamic`. Resolution order is therefore data-driven, not declaration order (see
-`test_template_needs`). Circular/missing dependencies are detected because a
-provider is `pop`-ed from `self.providers` before it runs — a re-entrant request
-for a not-yet-resolved, no-longer-pending key raises.
+`process_dynamic_metadata(project, entries, build_state)` is the entry point.
+`entries` is the **ordered list** of `[[tool.dynamic-metadata]]` tables. It
+builds a plain `dict` and applies entries in order: each provider gets a
+read-only `MappingProxyType` snapshot of the project resolved so far, so a later
+entry reads an earlier one's result with `project[...]` (a forward reference is
+just a `KeyError`; cycles are structurally impossible). The returned fragment is
+merged per field by `_merge_metadata` — lists append, tables add keys (PEP 808
+add-only), and a single-value field is replaced if a later entry targets it (a
+`produced` set distinguishes a prior entry's result from a static value, which
+for a scalar is the rejected static+dynamic case). Each resolved field is
+removed from `dynamic`.
 
 ### Shared value-shaping helper — `plugins/__init__.py`
 
@@ -83,7 +92,7 @@ encouraged to reuse or vendor.
 - `regex.py` — extract a value from a file via regex (default targets
   `__version__`/`VERSION`).
 - `template.py` — `str.format` substitution using `{project[...]}`,
-  demonstrating cross-field references.
+  demonstrating cross-field references (reading earlier entries' results).
 - `setuptools_scm.py` / `fancy_pypi_readme.py` — wrap external tools; both
   lazy-import their dependency inside the hook and declare it via
   `get_requires_for_dynamic_metadata`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,9 @@ is still WiP and may change.
 The library is split into three audiences (see README.md):
 
 - **Users** configure plugins as an ordered array of tables,
-  `[[tool.dynamic-metadata]]`, each with a `provider` (module path) and optional
-  `provider-path` (local dir). Entries run in order.
+  `[[tool.dynamic-metadata]]`, each with a `provider` (a module, or a
+  `module:Class`) and optional `provider-path` (local dir). Entries run in
+  order.
 - **Plugin authors** implement the hooks; they do _not_ need to depend on this
   package at runtime.
 - **Backend authors** consume `loader.py` to drive plugins; they also do not
@@ -44,10 +45,15 @@ warnings as errors and uses `--strict-markers --strict-config`.
 
 ### The plugin protocol
 
-A plugin is any module exposing
-`dynamic_metadata(settings, project, build_state) -> dict[str, Any]`. It returns
-a fragment of the `[project]` table (`{field: value, ...}`), so one plugin may
-set several fields. Two optional hooks:
+A provider is either a module or a class (`provider = "module:Class"`); a class
+is instantiated with no args by `load_provider` and its hooks are bound methods
+(so they can share state via `self`). The one required hook is
+`dynamic_metadata(settings, project) -> dict[str, Any]`. It returns a fragment
+of the `[project]` table (`{field: value, ...}`), so one plugin may set several
+fields. Three optional hooks: `build_state(build_state) -> None` (called once
+before `dynamic_metadata` with the current build state — a provider that cares
+stashes it, typically on `self`; the loader detects it via
+`isinstance(provider, DynamicMetadataBuildStateProtocol)`),
 `dynamic_wheel(settings) -> dict[str, bool]` (per-field METADATA 2.2 dynamic
 status; version must be false) and
 `get_requires_for_dynamic_metadata(settings) -> list[str]` (extra build

--- a/README.md
+++ b/README.md
@@ -19,20 +19,25 @@ https://github.com/scikit-build/scikit-build-core/issues/230.
 
 ## For users
 
-Every external plugin must specify a "provider", which is a module that provides
-the API listed in the next section.
+Plugins are configured as an **ordered array of tables**,
+`[[tool.dynamic-metadata]]`. Each entry must specify a `provider` (a module
+exposing the API in the next section); everything else in the entry is passed to
+that plugin as settings.
 
 ```toml
-[tool.dynamic-metadata.<field-name>]
+[[tool.dynamic-metadata]]
 provider = "<module>"
+# ... plugin settings ...
 ```
 
-There is an optional field: "provider-path", which specifies a local path to
-load a plugin from, allowing plugins to reside inside your own project.
+Entries run **in order**, so a later entry sees every field an earlier entry
+produced. This makes resolution order explicit (no dependency graph), lets you
+modify one field with several plugins, and means a plugin can read another
+field's value simply with `project[...]`.
 
-All other fields are passed on to the plugin, allowing plugins to specify custom
-configuration per field. Plugins can, if desired, use their own `tool.*`
-sections as well.
+There is an optional key, `provider-path`, which specifies a local directory to
+load the plugin from, allowing plugins to live inside your own project. Plugins
+can, if desired, use their own `tool.*` sections as well.
 
 ### Example: regex
 
@@ -46,24 +51,24 @@ build-backend = "..."
 [project]
 dynamic = ["version"]
 
-[tool.dynamic-metadata.version]
+[[tool.dynamic-metadata]]
 provider = "dynamic_metadata.plugins.regex"
+field = "version"
 input = "src/my_package/__init__.py"
 regex = '(?i)^(__version__|VERSION) *= *([\'"])v?(?P<value>.+?)\2'
 ```
 
-In this case, since the plugin lives inside `dynamic-metadata`, you have to
-include that in your requirements. Make sure the version is marked dynamic in
-your project table. And then you specify `version.provider`. The other options
-are defined by the plugin; this one takes a required `input` file and an
-optional `regex` (which defaults to the expression you see above). The regex
-optional `regex` (which defaults to the expression you see above). The regex
-needs to have a `"value"` named group (`?P<value>`), which it will set.
+Since this plugin lives inside `dynamic-metadata`, you have to include that in
+your requirements. Make sure the field is marked dynamic in your project table.
+The settings are defined by the plugin; this one takes the target `field`, a
+required `input` file, and an optional `regex` (which defaults to the expression
+above). The regex needs a `"value"` named group (`?P<value>`), which it will
+set.
 
 ### Mixing static and dynamic values (PEP 808)
 
 Following [PEP 808][], list and table fields can be given a static value in
-`[project]` _and_ listed in `dynamic` at the same time. The provider may only
+`[project]` _and_ listed in `dynamic` at the same time. A provider may only
 **add** to the static portion — it cannot remove, reorder, or change existing
 entries.
 
@@ -72,22 +77,25 @@ entries.
 dependencies = ["torch", "packaging"]
 dynamic = ["dependencies"]
 
-[tool.dynamic-metadata.dependencies]
+[[tool.dynamic-metadata]]
 provider = "..."
+field = "dependencies"
 ```
 
-The provider returns only its additions; the loader merges them onto the static
-value, with static entries kept first and the provider's entries appended
-verbatim. A provider may read the static value of the field it is extending via
-`project[...]` (e.g. `project["dependencies"]`) to decide what to add —
-requesting any _other_ unresolved field works too, but requesting one whose own
-provider is still running is a circular dependency and raises. For tables
-(`urls`, `scripts`, `entry-points`, `optional-dependencies`, …) the provider may
-add keys but not change the value of an existing one.
+The provider returns only its additions; the loader merges them onto the current
+value, with existing entries kept first and the provider's entries appended
+verbatim. A provider may read the value of any field already resolved (the
+static value of the field it is extending, or any field produced by an earlier
+entry) via `project[...]` to decide what to add; reading a field that has not
+been produced yet raises a `KeyError`. For tables (`urls`, `scripts`,
+`entry-points`, `optional-dependencies`, …) the provider may add keys but not
+change the value of an existing one.
 
-This applies to every list/table field; the single-value string fields
-(`version`, `description`, `requires-python`, `license`) and `readme` cannot be
-extended and so may only be fully static or fully dynamic.
+This add-only merge applies to every list/table field. The single-value fields
+(`version`, `description`, `requires-python`, `license`, and `readme`) cannot be
+extended, so they may not be both static and dynamic; a later entry targeting
+one of them instead **replaces** the value (a transform pipeline — for example,
+one plugin extracts a version and a later one normalizes it).
 
 [PEP 808]: https://peps.python.org/pep-0808/
 
@@ -103,14 +111,24 @@ implement; one required hook and two optional hooks. The required hook is:
 
 ```python
 def dynamic_metadata(
-    field: str,
     settings: Mapping[str, Any],
     project: Mapping[str, Any],
     build_state: str,
-) -> str | dict[str, Any]: ...  # return the value of the metadata
+) -> dict[str, Any]: ...  # return a fragment of [project], e.g. {"version": ...}
 ```
 
-The backend will call this hook in the same directory as PEP 517's hooks.
+The hook returns a **dict** that is a fragment of the `[project]` table — a
+mapping of field name to value, such as `{"version": "1.2.3"}` or
+`{"dependencies": ["numpy"]}`. The framework merges it into the project. One
+plugin may set several fields at once, and every returned field must be listed
+in `[project].dynamic`.
+
+The hook no longer receives a `field` argument: a single-purpose plugin
+(`setuptools_scm`, `fancy_pypi_readme`) hardcodes which field it produces, while
+a generic plugin (`regex`, `template`) reads the target field from a `field`
+setting. `project` is a read-only mapping of the project as resolved so far;
+read another field's value with `project["version"]`. The backend calls this
+hook in the same directory as PEP 517's hooks.
 
 `build_state` is a string the backend supplies describing the current build. It
 must be one of scikit-build-core's five build states: `"sdist"`, `"wheel"`,
@@ -125,16 +143,15 @@ A plugin can return METADATA 2.2 dynamic status:
 
 ```python
 def dynamic_wheel(
-    field: str,
     settings: Mapping[str, Any],
-) -> (
-    bool
-): ...  # Return true if metadata can change from SDist to wheel (METADATA 2.2 feature)
+) -> dict[str, bool]: ...  # map each field set -> may it change from SDist to wheel?
 ```
 
-If this hook is not implemented, it will default to "false". Note that "version"
-must always return "false". This hook is called after the main hook, so you do
-not need to validate the input here.
+It returns a map from each field this plugin sets to whether that field's value
+can change between the SDist and the wheel (the METADATA 2.2 feature). A field
+not present defaults to "false", and `"version"` must always be "false". This
+hook is called after the main hook, so you do not need to validate the input
+here.
 
 A plugin can also decide at runtime if it needs extra dependencies:
 
@@ -149,39 +166,37 @@ for plugins that require a CLI tool that has an optional compiled component.
 
 ### Example: regex
 
-Here is the regex plugin example implementation:
+Here is a simplified version of the regex plugin:
 
 ```python
 def dynamic_metadata(
-    field: str,
     settings: Mapping[str, Any],
     _project: Mapping[str, Any],
     _build_state: str,
-) -> str:
+) -> dict[str, Any]:
     # Input validation
-    if field not in {"version", "description", "requires-python"}:
-        raise RuntimeError("Only string fields supported by this plugin")
-    if settings.keys() - {"input", "regex"}:
-        raise RuntimeError("Only 'input' and 'regex' settings allowed by this plugin")
+    if settings.keys() - {"field", "input", "regex"}:
+        raise RuntimeError("Only 'field', 'input', and 'regex' settings allowed")
+    if "field" not in settings:
+        raise RuntimeError("Must contain the 'field' setting naming the target")
     if "input" not in settings:
         raise RuntimeError("Must contain the 'input' setting to perform a regex on")
     if not all(isinstance(x, str) for x in settings.values()):
-        raise RuntimeError("Must set 'input' and/or 'regex' to strings")
+        raise RuntimeError("All settings must be strings")
 
-    input = settings["input"]
-    # If not explicitly specified in the `tool.dynamic-metadata.<field-name>` table,
-    # the default regex provided below is used.
+    field = settings["field"]
+    # If not explicitly specified in the entry, the default regex below is used.
     regex = settings.get(
         "regex", r'(?i)^(__version__|VERSION) *= *([\'"])v?(?P<value>.+?)\2'
     )
 
-    with Path(input).open(encoding="utf-8") as f:
+    with Path(settings["input"]).open(encoding="utf-8") as f:
         match = re.search(regex, f.read())
 
     if not match:
-        raise RuntimeError(f"Couldn't find {regex!r} in {file}")
+        raise RuntimeError(f"Couldn't find {regex!r} in {settings['input']}")
 
-    return match.groups("value")
+    return {field: match.group("value")}
 ```
 
 ## For backend authors
@@ -191,9 +206,11 @@ library provides some helper functions you can use if you want, but you can
 implement them yourself following the standard provided or vendor the helper
 file (which will be tested and supported).
 
-You should collect the contents of `tool.dynamic-metadata` and load each one.
-You should respect requests for metadata from other plugins, as well; to see how
-to do that, refer to `src/dynamic-metadata/loader.py`.
+Collect the array of `[[tool.dynamic-metadata]]` entries and process them in
+order: load each entry's `provider`, call its `dynamic_metadata` hook with a
+snapshot of the project resolved so far, and merge the returned fragment in.
+Because the order is explicit, there is no dependency graph to compute — see
+`src/dynamic_metadata/loader.py` for the reference loop.
 
 <!-- prettier-ignore-start -->
 [actions-badge]:            https://github.com/scikit-build/dynamic-metadata/workflows/CI/badge.svg

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ https://github.com/scikit-build/scikit-build-core/issues/230.
 ## For users
 
 Plugins are configured as an **ordered array of tables**,
-`[[tool.dynamic-metadata]]`. Each entry must specify a `provider` (a module
-exposing the API in the next section); everything else in the entry is passed to
-that plugin as settings.
+`[[tool.dynamic-metadata]]`. Each entry must specify a `provider` exposing the
+API in the next section; everything else in the entry is passed to that plugin
+as settings. A `provider` is either a module (`"<module>"`) or a class within a
+module (`"<module>:<Class>"`); a class is instantiated and its hooks are called
+as methods.
 
 ```toml
 [[tool.dynamic-metadata]]
-provider = "<module>"
+provider = "<module>"        # or "<module>:<Class>"
 # ... plugin settings ...
 ```
 
@@ -107,13 +109,15 @@ runtime, along with a reference implementation that you can either use as an
 example, or use directly if you are fine to require the dependency.
 
 Like PEP 517's hooks, `dynamic-metadata` defines a set of hooks that you can
-implement; one required hook and two optional hooks. The required hook is:
+implement; one required hook and three optional hooks. A provider is either a
+module exposing these hooks as functions, or a class (`"<module>:<Class>"`)
+exposing them as methods — a class is instantiated with no arguments, so its
+hooks share state through `self`. The required hook is:
 
 ```python
 def dynamic_metadata(
     settings: Mapping[str, Any],
     project: Mapping[str, Any],
-    build_state: str,
 ) -> dict[str, Any]: ...  # return a fragment of [project], e.g. {"version": ...}
 ```
 
@@ -130,14 +134,24 @@ setting. `project` is a read-only mapping of the project as resolved so far;
 read another field's value with `project["version"]`. The backend calls this
 hook in the same directory as PEP 517's hooks.
 
+There are three optional hooks.
+
+A plugin can receive the current build state:
+
+```python
+def build_state(
+    build_state: str,
+) -> None: ...  # called before dynamic_metadata with the current build state
+```
+
 `build_state` is a string the backend supplies describing the current build. It
 must be one of scikit-build-core's five build states: `"sdist"`, `"wheel"`,
 `"editable"`, `"metadata_wheel"`, or `"metadata_editable"` (the latter two are
-the `prepare_metadata_for_build_*` phases). A plugin may use it — for example to
-reuse a value already computed in an SDist's `PKG-INFO` instead of recomputing
-it for the wheel — or ignore it.
-
-There are two optional hooks.
+the `prepare_metadata_for_build_*` phases). This hook is called once, before
+`dynamic_metadata`. A plugin may use it — for example to reuse a value already
+computed in an SDist's `PKG-INFO` instead of recomputing it for the wheel — by
+stashing it (typically on `self` in a class provider) for `dynamic_metadata` to
+read; a plugin that does not care simply omits this hook.
 
 A plugin can return METADATA 2.2 dynamic status:
 
@@ -172,7 +186,6 @@ Here is a simplified version of the regex plugin:
 def dynamic_metadata(
     settings: Mapping[str, Any],
     _project: Mapping[str, Any],
-    _build_state: str,
 ) -> dict[str, Any]:
     # Input validation
     if settings.keys() - {"field", "input", "regex"}:

--- a/src/dynamic_metadata/info.py
+++ b/src/dynamic_metadata/info.py
@@ -6,6 +6,7 @@ __all__ = [
     "EXTENDABLE_FIELDS",
     "LIST_DICT_FIELDS",
     "LIST_STR_FIELDS",
+    "SCALAR_FIELDS",
     "STR_FIELDS",
 ]
 
@@ -43,6 +44,10 @@ LIST_DICT_FIELDS = frozenset(
         "maintainers",
     ]
 )
+
+# Single-value fields: a later entry replaces the value rather than extending it,
+# and PEP 808 forbids giving them both statically and dynamically.
+SCALAR_FIELDS = STR_FIELDS | frozenset(["readme"])
 
 # "dynamic" and "name" can't be set or requested
 ALL_FIELDS = (

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import dataclasses
 import importlib
 import importlib.abc
 import importlib.machinery
 import sys
-from collections.abc import Iterator, Mapping
 from pathlib import Path
+from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -23,6 +22,7 @@ from .info import (
     EXTENDABLE_FIELDS,
     LIST_DICT_FIELDS,
     LIST_STR_FIELDS,
+    SCALAR_FIELDS,
 )
 
 BuildState = Literal[
@@ -31,13 +31,9 @@ BuildState = Literal[
 BUILD_STATES: frozenset[str] = frozenset(get_args(BuildState))
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
+    from collections.abc import Generator, Mapping, Sequence
     from importlib.machinery import ModuleSpec
     from types import ModuleType
-
-    StrMapping = Mapping[str, Any]
-else:
-    StrMapping = Mapping
 
 
 __all__ = [
@@ -56,23 +52,22 @@ def __dir__() -> list[str]:
 class DynamicMetadataProtocol(Protocol):
     def dynamic_metadata(
         self,
-        field: str,
-        settings: dict[str, Any],
+        settings: Mapping[str, Any],
         project: Mapping[str, Any],
         build_state: BuildState,
-    ) -> Any: ...
+    ) -> dict[str, Any]: ...
 
 
 @runtime_checkable
 class DynamicMetadataRequirementsProtocol(DynamicMetadataProtocol, Protocol):
     def get_requires_for_dynamic_metadata(
-        self, settings: dict[str, Any]
+        self, settings: Mapping[str, Any]
     ) -> list[str]: ...
 
 
 @runtime_checkable
 class DynamicMetadataWheelProtocol(DynamicMetadataProtocol, Protocol):
-    def dynamic_wheel(self, field: str, settings: Mapping[str, Any]) -> bool: ...
+    def dynamic_wheel(self, settings: Mapping[str, Any]) -> dict[str, bool]: ...
 
 
 DMProtocols = Union[
@@ -80,6 +75,10 @@ DMProtocols = Union[
     DynamicMetadataRequirementsProtocol,
     DynamicMetadataWheelProtocol,
 ]
+
+# Per-entry keys consumed by the loader itself; everything else is plugin
+# settings, passed through verbatim to the provider.
+RESERVED_KEYS = frozenset(["provider", "provider-path"])
 
 
 class _ProviderPathFinder(importlib.abc.MetaPathFinder):
@@ -131,11 +130,13 @@ def _merge_dict(
 
 
 def _merge_metadata(field: str, static: Any, dynamic: Any) -> Any:
-    """Merge a static value with a provider's additions (PEP 808).
+    """Merge a current value with a provider's additions (PEP 808).
 
-    Existing static entries are preserved as-is and kept first; the provider's
-    value is appended after them. Lists are concatenated verbatim, so a provider
-    should return only its additions and may add a value already present.
+    Existing entries are preserved as-is and kept first; the provider's value is
+    appended after them. Lists are concatenated verbatim, so a provider should
+    return only its additions and may add a value already present. Single-value
+    fields (string fields, readme) cannot be extended; merging onto a static
+    value of one is the invalid "static *and* dynamic" case and raises.
     """
     if field not in EXTENDABLE_FIELDS:
         msg = f"Field {field!r} cannot be given both statically and dynamically"
@@ -182,99 +183,35 @@ def load_provider(
 
 
 def load_dynamic_metadata(
-    metadata: Mapping[str, Mapping[str, Any]],
-) -> Generator[tuple[str, DMProtocols | None, dict[str, str]], None, None]:
-    for field, orig_config in metadata.items():
-        if "provider" in orig_config:
-            if field not in ALL_FIELDS:
-                msg = f"{field} is not a valid field"
-                raise KeyError(msg)
-            config = dict(orig_config)
-            provider = config.pop("provider")
-            provider_path = config.pop("provider-path", None)
-            loaded_provider = load_provider(provider, provider_path)
-            yield field, loaded_provider, config
-        else:
-            yield field, None, dict(orig_config)
+    entries: Sequence[Mapping[str, Any]],
+) -> Generator[tuple[DMProtocols, dict[str, Any]], None, None]:
+    """Load each entry's provider, yielding it with its plugin settings.
 
-
-@dataclasses.dataclass
-class DynamicPyProject(StrMapping):
-    settings: dict[str, dict[str, Any]]
-    project: dict[str, Any]
-    providers: dict[str, DMProtocols]
-    build_state: BuildState
-    # Stack of fields whose providers are currently running, innermost last.
-    _resolving: list[str] = dataclasses.field(default_factory=list)
-
-    def __getitem__(self, key: str) -> Any:
-        # PEP 808: a provider may read the static value of the field it is
-        # itself resolving (the innermost in-flight field) to decide what to
-        # add. Any other in-flight field is a circular dependency, handled below.
-        if self._resolving and self._resolving[-1] == key and key in self.project:
-            return self.project[key]
-
-        # Static-only fields, and providers that have already resolved, are
-        # returned as-is. An in-flight field is excluded so a re-entrant request
-        # for it is not answered with its incomplete (static-only) value.
-        if (
-            key in self.project
-            and key not in self.providers
-            and key not in self._resolving
-        ):
-            return self.project[key]
-
-        # Check if we are in a loop, i.e. something else is already requesting
-        # this key while trying to get another key
-        if key not in self.providers:
-            dep_type = "circular" if key in self.settings else "missing"
-            msg = f"Encountered a {dep_type} dependency at {key}"
-            raise ValueError(msg)
-
-        provider = self.providers.pop(key)
-        self._resolving.append(key)
-        try:
-            result = provider.dynamic_metadata(
-                key, self.settings[key], self, self.build_state
-            )
-        finally:
-            self._resolving.pop()
-        if key in self.project:
-            # PEP 808: the field is given both statically and dynamically, so
-            # the provider's result only adds to the static portion.
-            result = _merge_metadata(key, self.project[key], result)
-        self.project[key] = result
-        self.project["dynamic"].remove(key)
-
-        return self.project[key]
-
-    def __iter__(self) -> Iterator[str]:
-        # Iterate over static and provider keys, without repeating a PEP 808
-        # field that appears in both.
-        seen: set[str] = set()
-        for key in (*self.project, *self.providers):
-            if key not in seen:
-                seen.add(key)
-                yield key
-
-    def __len__(self) -> int:
-        return len(self.project.keys() | self.providers.keys())
-
-    def __contains__(self, key: object) -> bool:
-        return key in self.project or key in self.providers
+    Entries are processed in order; ``provider`` and ``provider-path`` are
+    consumed here and the remaining keys are returned as plugin settings.
+    """
+    for entry in entries:
+        if "provider" not in entry:
+            msg = "Each [[tool.dynamic-metadata]] entry must set a 'provider'"
+            raise KeyError(msg)
+        settings = {k: v for k, v in entry.items() if k not in RESERVED_KEYS}
+        provider = load_provider(entry["provider"], entry.get("provider-path"))
+        yield provider, settings
 
 
 def process_dynamic_metadata(
     project: Mapping[str, Any],
-    metadata: Mapping[str, Mapping[str, Any]],
+    entries: Sequence[Mapping[str, Any]],
     build_state: BuildState,
 ) -> dict[str, Any]:
     """Process dynamic metadata.
 
-    This function loads the dynamic metadata providers and calls them to
-    generate the dynamic metadata. It takes the original project table and
-    returns a new project table. Empty providers are not supported; you
-    need to implement this yourself for now if you support that.
+    Takes the original ``[project]`` table and an ordered list of
+    ``[[tool.dynamic-metadata]]`` entries, and returns a new project table.
+    Entries run in list order: each provider is called with a read-only snapshot
+    of the project as resolved so far, so a later entry can read a field an
+    earlier one produced via ``project[...]``. A provider returns a ``dict``
+    fragment of the project table (``{field: value, ...}``) which is merged in.
 
     ``build_state`` is the backend's description of the current build, passed
     through to each provider. It must be one of these build states
@@ -287,20 +224,43 @@ def process_dynamic_metadata(
         msg = f"build_state must be one of {sorted(BUILD_STATES)}, got {build_state!r}"
         raise ValueError(msg)
 
-    settings: dict[str, dict[str, Any]] = {}
-    providers: dict[str, DMProtocols] = {}
-    for field, provider, config in load_dynamic_metadata(metadata):
-        if provider is None:
-            msg = f"{field} does not have a provider"
-            raise KeyError(msg)
-        settings[field] = config
-        providers[field] = provider
+    result = dict(project)
+    result["dynamic"] = list(result.get("dynamic", []))
+    declared_dynamic = set(result["dynamic"])
+    snapshot = MappingProxyType(result)
 
-    dynamic = DynamicPyProject(
-        settings=settings,
-        project=dict(project),
-        providers=providers,
-        build_state=build_state,
-    )
+    # Fields already written by an earlier entry: a further entry merges onto
+    # that result (and may *replace* a scalar), as opposed to a static value
+    # still sitting in [project], which is the PEP 808 add-only case.
+    produced: set[str] = set()
 
-    return dict(dynamic)
+    for provider, settings in load_dynamic_metadata(entries):
+        fragment = provider.dynamic_metadata(settings, snapshot, build_state)
+
+        for field in fragment:
+            if field not in ALL_FIELDS:
+                msg = f"{field!r} is not a settable dynamic-metadata field"
+                raise KeyError(msg)
+            if field not in declared_dynamic:
+                msg = f"{field!r} must be listed in project.dynamic to be set"
+                raise KeyError(msg)
+
+        for field, value in fragment.items():
+            if field in produced:
+                # A second entry for this field: extend its prior result, or for
+                # a single-value field replace it (a transform pipeline).
+                result[field] = (
+                    value
+                    if field in SCALAR_FIELDS
+                    else _merge_metadata(field, result[field], value)
+                )
+            elif field in result:
+                # PEP 808: a static value is present; the provider only adds.
+                result[field] = _merge_metadata(field, result[field], value)
+            else:
+                result[field] = value
+            produced.add(field)
+            if field in result["dynamic"]:
+                result["dynamic"].remove(field)
+
+    return result

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -54,8 +54,12 @@ class DynamicMetadataProtocol(Protocol):
         self,
         settings: Mapping[str, Any],
         project: Mapping[str, Any],
-        build_state: BuildState,
     ) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class DynamicMetadataBuildStateProtocol(DynamicMetadataProtocol, Protocol):
+    def build_state(self, build_state: BuildState) -> None: ...
 
 
 @runtime_checkable
@@ -72,6 +76,7 @@ class DynamicMetadataWheelProtocol(DynamicMetadataProtocol, Protocol):
 
 DMProtocols = Union[
     DynamicMetadataProtocol,
+    DynamicMetadataBuildStateProtocol,
     DynamicMetadataRequirementsProtocol,
     DynamicMetadataWheelProtocol,
 ]
@@ -167,19 +172,31 @@ def load_provider(
     provider: str,
     provider_path: str | None = None,
 ) -> DMProtocols:
+    """Load a provider, returning the object whose hooks are called.
+
+    ``provider`` is either a module path (``"pkg.mod"``) or a module path and a
+    class within it (``"pkg.mod:Class"``). A bare module is returned as-is, so
+    its hooks are plain module-level functions; a class is instantiated with no
+    arguments and the instance is returned, so its hooks are bound methods and
+    may share state through ``self`` (e.g. the optional ``build_state`` hook
+    stashing the build state for ``dynamic_metadata`` to read).
+    """
+    module_name, _, class_name = provider.partition(":")
+
     if provider_path is None:
-        return importlib.import_module(provider)
+        module = importlib.import_module(module_name)
+    else:
+        if not Path(provider_path).is_dir():
+            msg = "provider-path must be an existing directory"
+            raise AssertionError(msg)
+        finder = _ProviderPathFinder([provider_path], module_name)
+        sys.meta_path.insert(0, finder)
+        try:
+            module = importlib.import_module(module_name)
+        finally:
+            sys.meta_path.remove(finder)
 
-    if not Path(provider_path).is_dir():
-        msg = "provider-path must be an existing directory"
-        raise AssertionError(msg)
-
-    finder = _ProviderPathFinder([provider_path], provider)
-    sys.meta_path.insert(0, finder)
-    try:
-        return importlib.import_module(provider)
-    finally:
-        sys.meta_path.remove(finder)
+    return getattr(module, class_name)() if class_name else module
 
 
 def load_dynamic_metadata(
@@ -213,11 +230,12 @@ def process_dynamic_metadata(
     earlier one produced via ``project[...]``. A provider returns a ``dict``
     fragment of the project table (``{field: value, ...}``) which is merged in.
 
-    ``build_state`` is the backend's description of the current build, passed
-    through to each provider. It must be one of these build states
-    (``BUILD_STATES``): ``"sdist"``, ``"wheel"``, ``"editable"``,
-    ``"metadata_wheel"``, or ``"metadata_editable"``. Providers may use it or
-    ignore it.
+    ``build_state`` is the backend's description of the current build. It must
+    be one of these build states (``BUILD_STATES``): ``"sdist"``, ``"wheel"``,
+    ``"editable"``, ``"metadata_wheel"``, or ``"metadata_editable"``. A provider
+    that cares about it implements an optional ``build_state`` hook, called with
+    this value before ``dynamic_metadata``; providers that ignore it simply omit
+    the hook.
     """
 
     if build_state not in BUILD_STATES:
@@ -235,7 +253,9 @@ def process_dynamic_metadata(
     produced: set[str] = set()
 
     for provider, settings in load_dynamic_metadata(entries):
-        fragment = provider.dynamic_metadata(settings, snapshot, build_state)
+        if isinstance(provider, DynamicMetadataBuildStateProtocol):
+            provider.build_state(build_state)
+        fragment = provider.dynamic_metadata(settings, snapshot)
 
         for field in fragment:
             if field not in ALL_FIELDS:

--- a/src/dynamic_metadata/plugins/__init__.py
+++ b/src/dynamic_metadata/plugins/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from ..info import DICT_STR_FIELDS, LIST_DICT_FIELDS, LIST_STR_FIELDS, STR_FIELDS
 
@@ -9,6 +9,25 @@ T = typing.TypeVar(
     "T",
     bound="str | list[str] | list[dict[str, str]] | dict[str, str] | dict[str, list[str]] | dict[str, dict[str, str]]",
 )
+
+
+def _require_field(settings: Mapping[str, typing.Any], allowed: set[str]) -> str:
+    """Validate the shared settings shape and return the target ``field`` name.
+
+    Generic plugins (regex, template) accept a fixed set of keys and a required
+    ``field`` naming the metadata field to set.
+    """
+    if settings.keys() - allowed:
+        msg = f"Only {allowed} settings allowed by this plugin"
+        raise RuntimeError(msg)
+    if "field" not in settings:
+        msg = "Must contain the 'field' setting naming the field to set"
+        raise RuntimeError(msg)
+    field = settings["field"]
+    if not isinstance(field, str):
+        msg = "The 'field' setting must be a string"
+        raise RuntimeError(msg)
+    return field
 
 
 def _process_dynamic_metadata(field: str, action: Callable[[str], str], result: T) -> T:

--- a/src/dynamic_metadata/plugins/fancy_pypi_readme.py
+++ b/src/dynamic_metadata/plugins/fancy_pypi_readme.py
@@ -16,17 +16,12 @@ def __dir__() -> list[str]:
 
 
 def dynamic_metadata(
-    field: str,
     settings: dict[str, list[str] | str],
     project: Mapping[str, Any],
     _build_state: str,
-) -> dict[str, str | None]:
+) -> dict[str, Any]:
     from hatch_fancy_pypi_readme._builder import build_text
     from hatch_fancy_pypi_readme._config import load_and_validate_config
-
-    if field != "readme":
-        msg = "Only the 'readme' field is supported"
-        raise ValueError(msg)
 
     if settings:
         msg = "No inline configuration is supported"
@@ -54,8 +49,10 @@ def dynamic_metadata(
         text = build_text(config.fragments)  # type: ignore[call-arg]
 
     return {
-        "content-type": config.content_type,
-        "text": text,
+        "readme": {
+            "content-type": config.content_type,
+            "text": text,
+        }
     }
 
 

--- a/src/dynamic_metadata/plugins/fancy_pypi_readme.py
+++ b/src/dynamic_metadata/plugins/fancy_pypi_readme.py
@@ -18,7 +18,6 @@ def __dir__() -> list[str]:
 def dynamic_metadata(
     settings: dict[str, list[str] | str],
     project: Mapping[str, Any],
-    _build_state: str,
 ) -> dict[str, Any]:
     from hatch_fancy_pypi_readme._builder import build_text
     from hatch_fancy_pypi_readme._config import load_and_validate_config

--- a/src/dynamic_metadata/plugins/regex.py
+++ b/src/dynamic_metadata/plugins/regex.py
@@ -17,7 +17,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-KEYS = {"input", "regex", "result", "remove"}
+KEYS = {"field", "input", "regex", "result", "remove"}
 
 
 def _process(match: re.Match[str], remove: str, result: str) -> str:
@@ -28,18 +28,21 @@ def _process(match: re.Match[str], remove: str, result: str) -> str:
 
 
 def dynamic_metadata(
-    field: str,
     settings: Mapping[str, Any],
     _project: Mapping[str, Any],
     _build_state: str,
-) -> str:
+) -> dict[str, Any]:
     # Input validation
     if settings.keys() - KEYS:
         msg = f"Only {KEYS} settings allowed by this plugin"
         raise RuntimeError(msg)
+    if "field" not in settings:
+        msg = "Must contain the 'field' setting naming the field to set"
+        raise RuntimeError(msg)
     if "input" not in settings:
         msg = "Must contain the 'input' setting to perform a regex on"
         raise RuntimeError(msg)
+    field = settings["field"]
     if field != "version" and "regex" not in settings:
         msg = "Must contain the 'regex' setting if not getting version"
         raise RuntimeError(msg)
@@ -64,6 +67,8 @@ def dynamic_metadata(
         msg = f"Couldn't find {regex!r} in {input_filename}"
         raise RuntimeError(msg)
 
-    return _process_dynamic_metadata(
-        field, functools.partial(_process, match, remove), result
-    )
+    return {
+        field: _process_dynamic_metadata(
+            field, functools.partial(_process, match, remove), result
+        )
+    }

--- a/src/dynamic_metadata/plugins/regex.py
+++ b/src/dynamic_metadata/plugins/regex.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from . import _process_dynamic_metadata
+from . import _process_dynamic_metadata, _require_field
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -33,16 +33,10 @@ def dynamic_metadata(
     _build_state: str,
 ) -> dict[str, Any]:
     # Input validation
-    if settings.keys() - KEYS:
-        msg = f"Only {KEYS} settings allowed by this plugin"
-        raise RuntimeError(msg)
-    if "field" not in settings:
-        msg = "Must contain the 'field' setting naming the field to set"
-        raise RuntimeError(msg)
+    field = _require_field(settings, KEYS)
     if "input" not in settings:
         msg = "Must contain the 'input' setting to perform a regex on"
         raise RuntimeError(msg)
-    field = settings["field"]
     if field != "version" and "regex" not in settings:
         msg = "Must contain the 'regex' setting if not getting version"
         raise RuntimeError(msg)

--- a/src/dynamic_metadata/plugins/regex.py
+++ b/src/dynamic_metadata/plugins/regex.py
@@ -30,7 +30,6 @@ def _process(match: re.Match[str], remove: str, result: str) -> str:
 def dynamic_metadata(
     settings: Mapping[str, Any],
     _project: Mapping[str, Any],
-    _build_state: str,
 ) -> dict[str, Any]:
     # Input validation
     field = _require_field(settings, KEYS)

--- a/src/dynamic_metadata/plugins/setuptools_scm.py
+++ b/src/dynamic_metadata/plugins/setuptools_scm.py
@@ -8,17 +8,12 @@ def __dir__() -> list[str]:
 
 
 def dynamic_metadata(
-    field: str,
     settings: dict[str, object],
     _project: dict[str, object],
     _build_state: str,
-) -> str:
+) -> dict[str, object]:
     # this is a classic implementation, waiting for the release of
     # vcs-versioning and an improved public interface
-
-    if field != "version":
-        msg = "Only the 'version' field is supported"
-        raise ValueError(msg)
 
     if settings:
         msg = "No inline configuration is supported"
@@ -47,7 +42,7 @@ def dynamic_metadata(
 
         raise ValueError(msg)
 
-    return version
+    return {"version": version}
 
 
 def get_requires_for_dynamic_metadata(

--- a/src/dynamic_metadata/plugins/setuptools_scm.py
+++ b/src/dynamic_metadata/plugins/setuptools_scm.py
@@ -10,7 +10,6 @@ def __dir__() -> list[str]:
 def dynamic_metadata(
     settings: dict[str, object],
     _project: dict[str, object],
-    _build_state: str,
 ) -> dict[str, object]:
     # this is a classic implementation, waiting for the release of
     # vcs-versioning and an improved public interface

--- a/src/dynamic_metadata/plugins/template.py
+++ b/src/dynamic_metadata/plugins/template.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-from . import _process_dynamic_metadata
+from . import _process_dynamic_metadata, _require_field
 
 __all__ = ["dynamic_metadata"]
 
@@ -22,19 +22,12 @@ def dynamic_metadata(
     project: Mapping[str, Any],
     _build_state: str,
 ) -> dict[str, Any]:
-    if settings.keys() - KEYS:
-        msg = f"Only {KEYS} settings allowed by this plugin"
-        raise RuntimeError(msg)
-
-    if "field" not in settings:
-        msg = "Must contain the 'field' setting naming the field to set"
-        raise RuntimeError(msg)
+    field = _require_field(settings, KEYS)
 
     if "result" not in settings:
         msg = "Must contain the 'result' setting with a template substitution"
         raise RuntimeError(msg)
 
-    field = settings["field"]
     result = settings["result"]
 
     return {

--- a/src/dynamic_metadata/plugins/template.py
+++ b/src/dynamic_metadata/plugins/template.py
@@ -20,7 +20,6 @@ KEYS = {"field", "result"}
 def dynamic_metadata(
     settings: Mapping[str, Any],
     project: Mapping[str, Any],
-    _build_state: str,
 ) -> dict[str, Any]:
     field = _require_field(settings, KEYS)
 

--- a/src/dynamic_metadata/plugins/template.py
+++ b/src/dynamic_metadata/plugins/template.py
@@ -14,27 +14,33 @@ def __dir__() -> list[str]:
     return __all__
 
 
-KEYS = {"result"}
+KEYS = {"field", "result"}
 
 
 def dynamic_metadata(
-    field: str,
-    settings: Mapping[str, str | list[str] | dict[str, str] | dict[str, list[str]]],
+    settings: Mapping[str, Any],
     project: Mapping[str, Any],
     _build_state: str,
-) -> str | list[str] | dict[str, str] | dict[str, list[str]]:
+) -> dict[str, Any]:
     if settings.keys() - KEYS:
         msg = f"Only {KEYS} settings allowed by this plugin"
+        raise RuntimeError(msg)
+
+    if "field" not in settings:
+        msg = "Must contain the 'field' setting naming the field to set"
         raise RuntimeError(msg)
 
     if "result" not in settings:
         msg = "Must contain the 'result' setting with a template substitution"
         raise RuntimeError(msg)
 
+    field = settings["field"]
     result = settings["result"]
 
-    return _process_dynamic_metadata(
-        field,
-        lambda r: r.format(project=project),
-        result,
-    )
+    return {
+        field: _process_dynamic_metadata(
+            field,
+            lambda r: r.format(project=project),
+            result,
+        )
+    }

--- a/src/dynamic_metadata/resources/toml_schema.json
+++ b/src/dynamic_metadata/resources/toml_schema.json
@@ -2,25 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/scikit-build/dynamic-metadata/blob/main/src/dynamic-metadata/resources/toml_schema.json",
   "description": "Dynamic metadata plugin configuration.",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "version": { "$ref": "#/$defs/entry" },
-    "description": { "$ref": "#/$defs/entry" },
-    "readme": { "$ref": "#/$defs/entry" },
-    "requires-python": { "$ref": "#/$defs/entry" },
-    "license": { "$ref": "#/$defs/entry" },
-    "authors": { "$ref": "#/$defs/entry" },
-    "maintainers": { "$ref": "#/$defs/entry" },
-    "keywords": { "$ref": "#/$defs/entry" },
-    "classifiers": { "$ref": "#/$defs/entry" },
-    "urls": { "$ref": "#/$defs/entry" },
-    "scripts": { "$ref": "#/$defs/entry" },
-    "gui-scripts": { "$ref": "#/$defs/entry" },
-    "entry-points": { "$ref": "#/$defs/entry" },
-    "dependencies": { "$ref": "#/$defs/entry" },
-    "optional-dependencies": { "$ref": "#/$defs/entry" }
-  },
+  "type": "array",
+  "items": { "$ref": "#/$defs/entry" },
   "$defs": {
     "entry": {
       "type": "object",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -13,12 +13,12 @@ def test_load_provider_path_loads_local(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins"
     plugin_dir.mkdir()
     (plugin_dir / "local_prov_ok.py").write_text(
-        "def dynamic_metadata(field, settings, project, build_state):\n"
-        "    return '1.2.3'\n"
+        "def dynamic_metadata(settings, project, build_state):\n"
+        "    return {'version': '1.2.3'}\n"
     )
 
     provider = dynamic_metadata.loader.load_provider("local_prov_ok", str(plugin_dir))
-    assert provider.dynamic_metadata("version", {}, {}, "wheel") == "1.2.3"
+    assert provider.dynamic_metadata({}, {}, "wheel") == {"version": "1.2.3"}
 
 
 def test_load_provider_path_not_shadowed(
@@ -44,44 +44,171 @@ def test_template_basic() -> None:
             "version": "0.1.0",
             "dynamic": ["requires-python"],
         },
-        {
-            "requires-python": {
+        [
+            {
                 "provider": "dynamic_metadata.plugins.template",
+                "field": "requires-python",
                 "result": ">={project[version]}",
             },
-        },
+        ],
         "wheel",
     )
 
     assert pyproject["requires-python"] == ">=0.1.0"
+    assert pyproject["dynamic"] == []
 
 
-def test_template_needs() -> None:
-    # These are intentionally out of order to test the order of processing
+def test_template_order_reads_earlier_result() -> None:
+    # Entries run in list order; each later one reads what the earlier produced.
     pyproject = dynamic_metadata.loader.process_dynamic_metadata(
         {
             "name": "test",
             "version": "0.1.0",
             "dynamic": ["requires-python", "license", "readme"],
         },
-        {
-            "license": {
+        [
+            {
                 "provider": "dynamic_metadata.plugins.template",
-                "result": "{project[requires-python]}",
-            },
-            "readme": {
-                "provider": "dynamic_metadata.plugins.template",
-                "result": {"file": "{project[license]}"},
-            },
-            "requires-python": {
-                "provider": "dynamic_metadata.plugins.template",
+                "field": "requires-python",
                 "result": ">={project[version]}",
             },
-        },
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "license",
+                "result": "{project[requires-python]}",
+            },
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "readme",
+                "result": {"file": "{project[license]}"},
+            },
+        ],
         "wheel",
     )
 
     assert pyproject["requires-python"] == ">=0.1.0"
+    assert pyproject["license"] == ">=0.1.0"
+    assert pyproject["readme"] == {"file": ">=0.1.0"}
+    assert pyproject["dynamic"] == []
+
+
+def test_forward_reference_raises() -> None:
+    # Reading a field that a *later* entry produces is a forward reference: the
+    # value is simply not in the project snapshot yet.
+    with pytest.raises(KeyError):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": ["requires-python", "version"]},
+            [
+                {
+                    "provider": "dynamic_metadata.plugins.template",
+                    "field": "requires-python",
+                    "result": ">={project[version]}",
+                },
+                {
+                    "provider": "dynamic_metadata.plugins.template",
+                    "field": "version",
+                    "result": "1.0",
+                },
+            ],
+            "wheel",
+        )
+
+
+def test_multiple_entries_same_field_merge_in_order() -> None:
+    # Two entries may target one field; their contributions merge in order.
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["dependencies"]},
+        [
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "dependencies",
+                "result": ["a"],
+            },
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "dependencies",
+                "result": ["b"],
+            },
+        ],
+        "wheel",
+    )
+
+    assert pyproject["dependencies"] == ["a", "b"]
+    assert pyproject["dynamic"] == []
+
+
+def test_scalar_field_second_entry_replaces() -> None:
+    # A single-value field can be transformed by a later entry that reads it.
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["version"]},
+        [
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "version",
+                "result": "1.0",
+            },
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "version",
+                "result": "{project[version]}.post1",
+            },
+        ],
+        "wheel",
+    )
+
+    assert pyproject["version"] == "1.0.post1"
+
+
+def test_provider_sets_multiple_fields(tmp_path: Path) -> None:
+    # One entry's fragment may set several fields at once.
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "multi_prov.py").write_text(
+        "def dynamic_metadata(settings, project, build_state):\n"
+        "    return {'version': '1.2.3', 'requires-python': '>=3.8'}\n"
+    )
+
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["version", "requires-python"]},
+        [{"provider": "multi_prov", "provider-path": str(plugin_dir)}],
+        "wheel",
+    )
+
+    assert pyproject["version"] == "1.2.3"
+    assert pyproject["requires-python"] == ">=3.8"
+    assert pyproject["dynamic"] == []
+
+
+def test_unknown_field_rejected(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "bad_field_prov.py").write_text(
+        "def dynamic_metadata(settings, project, build_state):\n"
+        "    return {'not-a-field': 'x'}\n"
+    )
+
+    with pytest.raises(KeyError, match="settable"):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": ["version"]},
+            [{"provider": "bad_field_prov", "provider-path": str(plugin_dir)}],
+            "wheel",
+        )
+
+
+def test_field_not_declared_dynamic_rejected(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "undeclared_prov.py").write_text(
+        "def dynamic_metadata(settings, project, build_state):\n"
+        "    return {'version': '1.0'}\n"
+    )
+
+    with pytest.raises(KeyError, match=r"project\.dynamic"):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": []},
+            [{"provider": "undeclared_prov", "provider-path": str(plugin_dir)}],
+            "wheel",
+        )
 
 
 def test_template_entry_points() -> None:
@@ -90,18 +217,20 @@ def test_template_entry_points() -> None:
             "name": "test",
             "dynamic": ["version", "entry-points"],
         },
-        {
-            "version": {
+        [
+            {
                 "provider": "dynamic_metadata.plugins.template",
+                "field": "version",
                 "result": "1.2.3",
             },
-            "entry-points": {
+            {
                 "provider": "dynamic_metadata.plugins.template",
+                "field": "entry-points",
                 "result": {
                     "my_group": {"my_point": "my_app:script_{project[version]}"}
                 },
             },
-        },
+        ],
         "wheel",
     )
 
@@ -117,14 +246,15 @@ def test_regex() -> None:
             "version": "0.1.0",
             "dynamic": ["requires-python"],
         },
-        {
-            "requires-python": {
+        [
+            {
                 "provider": "dynamic_metadata.plugins.regex",
+                "field": "requires-python",
                 "input": "pyproject.toml",
                 "regex": r"name = \"(?P<name>.+)\"",
                 "result": ">={name}",
             },
-        },
+        ],
         "wheel",
     )
 
@@ -135,13 +265,14 @@ def test_regex_rejects_unknown_setting() -> None:
     with pytest.raises(RuntimeError, match="settings allowed"):
         dynamic_metadata.loader.process_dynamic_metadata(
             {"name": "test", "version": "0.1.0", "dynamic": ["requires-python"]},
-            {
-                "requires-python": {
+            [
+                {
                     "provider": "dynamic_metadata.plugins.regex",
+                    "field": "requires-python",
                     "input": "pyproject.toml",
                     "typo": "oops",
                 },
-            },
+            ],
             "wheel",
         )
 
@@ -152,21 +283,21 @@ def test_build_state_passed_to_provider(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins"
     plugin_dir.mkdir()
     (plugin_dir / "build_state_prov.py").write_text(
-        "def dynamic_metadata(field, settings, project, build_state):\n"
+        "def dynamic_metadata(settings, project, build_state):\n"
         "    if build_state in {'sdist', 'wheel'}:\n"
-        "        return 'computed'\n"
-        "    return 'reused'\n"
+        "        return {'version': 'computed'}\n"
+        "    return {'version': 'reused'}\n"
     )
 
     def run(build_state: dynamic_metadata.loader.BuildState) -> Any:
         return dynamic_metadata.loader.process_dynamic_metadata(
             {"name": "test", "dynamic": ["version"]},
-            {
-                "version": {
+            [
+                {
                     "provider": "build_state_prov",
                     "provider-path": str(plugin_dir),
                 },
-            },
+            ],
             build_state,
         )["version"]
 
@@ -179,7 +310,7 @@ def test_build_state_rejects_unknown_value() -> None:
     with pytest.raises(ValueError, match="build_state must be one of"):
         dynamic_metadata.loader.process_dynamic_metadata(
             {"name": "test", "version": "0.1.0"},
-            {},
+            [],
             "bdist",  # type: ignore[arg-type]
         )
 
@@ -193,12 +324,13 @@ def test_pep808_extends_static_dependencies() -> None:
             "dependencies": ["torch", "packaging"],
             "dynamic": ["dependencies"],
         },
-        {
-            "dependencies": {
+        [
+            {
                 "provider": "dynamic_metadata.plugins.template",
+                "field": "dependencies",
                 "result": ["numpy>={project[version]}"],
             },
-        },
+        ],
         "wheel",
     )
 
@@ -216,57 +348,17 @@ def test_pep808_provider_reads_own_static() -> None:
             "dependencies": ["a", "b"],
             "dynamic": ["dependencies"],
         },
-        {
-            "dependencies": {
+        [
+            {
                 "provider": "dynamic_metadata.plugins.template",
+                "field": "dependencies",
                 "result": ["saw:{project[dependencies]}"],
             },
-        },
+        ],
         "wheel",
     )
 
     assert pyproject["dependencies"] == ["a", "b", "saw:['a', 'b']"]
-
-
-def test_pep808_circular_dependency_detected() -> None:
-    # A static-and-dynamic field must not let its own static value satisfy a
-    # re-entrant request while its provider is mid-resolution: the cycle below
-    # (dependencies -> classifiers -> dependencies) must still be detected.
-    with pytest.raises(ValueError, match="circular"):
-        dynamic_metadata.loader.process_dynamic_metadata(
-            {
-                "name": "test",
-                "dependencies": ["a"],
-                "dynamic": ["dependencies", "classifiers"],
-            },
-            {
-                "dependencies": {
-                    "provider": "dynamic_metadata.plugins.template",
-                    "result": ["{project[classifiers]}"],
-                },
-                "classifiers": {
-                    "provider": "dynamic_metadata.plugins.template",
-                    "result": ["{project[dependencies]}"],
-                },
-            },
-            "wheel",
-        )
-
-
-def test_missing_dependency_detected() -> None:
-    # A reference to a field with neither a static value nor a provider is a
-    # missing (not circular) dependency.
-    with pytest.raises(ValueError, match="missing"):
-        dynamic_metadata.loader.process_dynamic_metadata(
-            {"name": "test", "dynamic": ["requires-python"]},
-            {
-                "requires-python": {
-                    "provider": "dynamic_metadata.plugins.template",
-                    "result": ">={project[nonexistent]}",
-                },
-            },
-            "wheel",
-        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -13,12 +13,31 @@ def test_load_provider_path_loads_local(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins"
     plugin_dir.mkdir()
     (plugin_dir / "local_prov_ok.py").write_text(
-        "def dynamic_metadata(settings, project, build_state):\n"
-        "    return {'version': '1.2.3'}\n"
+        "def dynamic_metadata(settings, project):\n    return {'version': '1.2.3'}\n"
     )
 
     provider = dynamic_metadata.loader.load_provider("local_prov_ok", str(plugin_dir))
-    assert provider.dynamic_metadata({}, {}, "wheel") == {"version": "1.2.3"}
+    assert provider.dynamic_metadata({}, {}) == {"version": "1.2.3"}
+
+
+def test_load_provider_class_is_instantiated(tmp_path: Path) -> None:
+    # A "module:Class" provider is imported and instantiated; its hooks are
+    # bound methods that may share state through ``self``.
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "class_prov.py").write_text(
+        "class Provider:\n"
+        "    def dynamic_metadata(self, settings, project):\n"
+        "        return {'version': '1.2.3'}\n"
+    )
+
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["version"]},
+        [{"provider": "class_prov:Provider", "provider-path": str(plugin_dir)}],
+        "wheel",
+    )
+
+    assert pyproject["version"] == "1.2.3"
 
 
 def test_load_provider_path_not_shadowed(
@@ -164,7 +183,7 @@ def test_provider_sets_multiple_fields(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins"
     plugin_dir.mkdir()
     (plugin_dir / "multi_prov.py").write_text(
-        "def dynamic_metadata(settings, project, build_state):\n"
+        "def dynamic_metadata(settings, project):\n"
         "    return {'version': '1.2.3', 'requires-python': '>=3.8'}\n"
     )
 
@@ -183,8 +202,7 @@ def test_unknown_field_rejected(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins"
     plugin_dir.mkdir()
     (plugin_dir / "bad_field_prov.py").write_text(
-        "def dynamic_metadata(settings, project, build_state):\n"
-        "    return {'not-a-field': 'x'}\n"
+        "def dynamic_metadata(settings, project):\n    return {'not-a-field': 'x'}\n"
     )
 
     with pytest.raises(KeyError, match="settable"):
@@ -199,8 +217,7 @@ def test_field_not_declared_dynamic_rejected(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins"
     plugin_dir.mkdir()
     (plugin_dir / "undeclared_prov.py").write_text(
-        "def dynamic_metadata(settings, project, build_state):\n"
-        "    return {'version': '1.0'}\n"
+        "def dynamic_metadata(settings, project):\n    return {'version': '1.0'}\n"
     )
 
     with pytest.raises(KeyError, match=r"project\.dynamic"):
@@ -277,16 +294,21 @@ def test_regex_rejects_unknown_setting() -> None:
         )
 
 
-def test_build_state_passed_to_provider(tmp_path: Path) -> None:
-    # The backend's build_state string reaches the provider and can drive its
-    # result: recompute for sdist/wheel, reuse a precomputed value otherwise.
+def test_build_state_hook_drives_result(tmp_path: Path) -> None:
+    # A provider with the optional build_state hook is told the build state
+    # before dynamic_metadata, and can drive its result from it: recompute for
+    # sdist/wheel, reuse a precomputed value otherwise. A class provider stashes
+    # the state on ``self`` for dynamic_metadata to read.
     plugin_dir = tmp_path / "plugins"
     plugin_dir.mkdir()
     (plugin_dir / "build_state_prov.py").write_text(
-        "def dynamic_metadata(settings, project, build_state):\n"
-        "    if build_state in {'sdist', 'wheel'}:\n"
-        "        return {'version': 'computed'}\n"
-        "    return {'version': 'reused'}\n"
+        "class Provider:\n"
+        "    def build_state(self, build_state):\n"
+        "        self.build_state = build_state\n"
+        "    def dynamic_metadata(self, settings, project):\n"
+        "        if self.build_state in {'sdist', 'wheel'}:\n"
+        "            return {'version': 'computed'}\n"
+        "        return {'version': 'reused'}\n"
     )
 
     def run(build_state: dynamic_metadata.loader.BuildState) -> Any:
@@ -294,7 +316,7 @@ def test_build_state_passed_to_provider(tmp_path: Path) -> None:
             {"name": "test", "dynamic": ["version"]},
             [
                 {
-                    "provider": "build_state_prov",
+                    "provider": "build_state_prov:Provider",
                     "provider-path": str(plugin_dir),
                 },
             ],


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

Redesigns the (experimental, unpublished) plugin model from a field-keyed table
resolved by a lazy "magic dict" to an **ordered array of tables**.

Before:
```toml
[tool.dynamic-metadata.version]
provider = "dynamic_metadata.plugins.regex"
input = "src/pkg/__init__.py"
```

After:
```toml
[[tool.dynamic-metadata]]
provider = "dynamic_metadata.plugins.regex"
field = "version"
input = "src/pkg/__init__.py"
```

Entries run **in list order**, so a later entry reads any field an earlier one
produced via a plain read-only `project` mapping. The hook is now field-less and
**always returns a dict fragment** of `[project]` (`{field: value, ...}`):

```python
def dynamic_metadata(settings, project, build_state) -> dict[str, Any]:
    return {"version": "1.2.3"}
```

`dynamic_wheel` returns a per-field `dict[str, bool]` to match. Deletes
`DynamicPyProject`, the `_resolving` stack, and cycle detection;
`process_dynamic_metadata(project, entries, build_state)` is now a plain ordered
loop.

## Pros

- **No magic dict for backends to reproduce.** The old `project` was a
  re-entrant resolver with lazy `__getitem__` and pop-before-run cycle
  detection. Now it is an ordinary `MappingProxyType` snapshot; a backend just
  loops the list and merges fragments. This was the main motivation.
- **Ordering is explicit and visible** in the file, instead of being a
  data-driven side effect of which plugin reads which field.
- **Cycles are structurally impossible**; a forward reference is a plain
  `KeyError` rather than bespoke "circular/missing dependency" logic.
- **New capability:** a field can be targeted by multiple entries (containers
  append; single-value fields replace -- a transform pipeline), and one plugin
  can set several fields at once via the returned dict.
- **Uniform hook shape** -- always a dict -- regardless of field type; no
  `field` parameter to thread through.
- Net simpler core: `loader.py` loses the `Mapping` subclass and all its dunder
  methods.

## Cons / trade-offs

- **Breaking change** to both config format and the hook signature. Everything
  here (config, all four bundled plugins, tests, docs) is updated, but any
  external plugin/backend would need to migrate. Acceptable while unpublished.
- **More verbose config** -- one `[[tool.dynamic-metadata]]` header and a
  `field = ` per entry, vs. a single field-keyed header. The `provider` is now
  its own line rather than the table name.
- **Author must order entries correctly.** The framework no longer figures out
  dependencies; if you reference a not-yet-produced field you get a `KeyError`.
  This is the intended tradeoff (explicit > implicit) but is slightly more
  effort.
- **Scalar replace is subtle.** A single-value field set by two entries
  silently replaces; the loader uses a `produced` set to keep distinguishing
  the rejected PEP 808 static+dynamic case from a legitimate transform pipeline.
  Worth a second look in review.
- `field` moving from a hook argument to a plugin setting means generic plugins
  (`regex`, `template`) validate it themselves; specialized plugins
  (`setuptools_scm`, `fancy_pypi_readme`) hardcode it.

## Open questions for review

- Keep scalar-replace (transform pipelines) at all, or forbid >1 writer for
  single-value fields?
- `dynamic_wheel(settings) -> dict[str, bool]` shape -- reasonable, or
  overthought for a rarely-used hook?
- Flat settings (chosen) vs. a nested `settings` table per entry.

## Verification

- `uv run pytest` -- 31 passing (rewritten for the list form; added forward-ref,
  multi-entry-merge, scalar-replace, multi-field, and validation tests).
- `prek -a` clean, including strict mypy.
- Sample configs validated against the new array-form JSON schema (valid array
  accepted; missing `provider` and the old object form rejected).
