### PR TITLE
refactor: simplify field taxonomy and fix doc/style nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,17 @@ dynamic = ["version"]
 provider = "dynamic_metadata.plugins.regex"
 field = "version"
 input = "src/my_package/__init__.py"
-regex = '(?i)^(__version__|VERSION) *= *([\'"])v?(?P<value>.+?)\2'
 ```
 
 Since this plugin lives inside `dynamic-metadata`, you have to include that in
 your requirements. Make sure the field is marked dynamic in your project table.
-The settings are defined by the plugin; this one takes the target `field`, a
-required `input` file, and an optional `regex` (which defaults to the expression
-above). The regex needs a `"value"` named group (`?P<value>`), which it will
-set.
+The settings are defined by the plugin; this one takes the target `field` and a
+required `input` file. The optional `regex` defaults to an expression that
+matches `__version__`/`VERSION` (with an optional `: str` annotation) and
+captures a `"value"` named group (`?P<value>`); supply your own to extract from
+a different pattern, keeping a `"value"` group. The optional `result` is a
+`str.format` template over the match (default `"{value}"`, with access to every
+numbered and named group), and `remove` is a regex stripped from the result.
 
 ### Mixing static and dynamic values (PEP 808)
 

--- a/src/dynamic_metadata/info.py
+++ b/src/dynamic_metadata/info.py
@@ -65,16 +65,7 @@ ALL_FIELDS = (
 )
 
 # Fields that PEP 808 allows to be given statically in [project] *and* listed in
-# dynamic, letting a provider only add to the static portion. String fields and
-# readme have a single value and so cannot be extended.
-EXTENDABLE_FIELDS = (
-    LIST_STR_FIELDS
-    | DICT_STR_FIELDS
-    | LIST_DICT_FIELDS
-    | frozenset(
-        [
-            "optional-dependencies",
-            "entry-points",
-        ]
-    )
-)
+# dynamic, letting a provider only add to the static portion: everything except
+# the scalar fields (string fields and readme), which hold a single value and so
+# cannot be extended.
+EXTENDABLE_FIELDS = ALL_FIELDS - SCALAR_FIELDS

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -188,7 +188,7 @@ def load_provider(
     else:
         if not Path(provider_path).is_dir():
             msg = "provider-path must be an existing directory"
-            raise AssertionError(msg)
+            raise ValueError(msg)
         finder = _ProviderPathFinder([provider_path], module_name)
         sys.meta_path.insert(0, finder)
         try:

--- a/src/dynamic_metadata/plugins/fancy_pypi_readme.py
+++ b/src/dynamic_metadata/plugins/fancy_pypi_readme.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 from .._compat import tomllib
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = [
     "dynamic_metadata",
@@ -16,7 +19,7 @@ def __dir__() -> list[str]:
 
 
 def dynamic_metadata(
-    settings: dict[str, list[str] | str],
+    settings: dict[str, object],
     project: Mapping[str, Any],
 ) -> dict[str, Any]:
     from hatch_fancy_pypi_readme._builder import build_text

--- a/src/dynamic_metadata/resources/toml_schema.json
+++ b/src/dynamic_metadata/resources/toml_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/scikit-build/dynamic-metadata/blob/main/src/dynamic-metadata/resources/toml_schema.json",
+  "$id": "https://github.com/scikit-build/dynamic-metadata/blob/main/src/dynamic_metadata/resources/toml_schema.json",
   "description": "Dynamic metadata plugin configuration.",
   "type": "array",
   "items": { "$ref": "#/$defs/entry" },


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A small review pass for simplifications, doc accuracy, and style consistency. No behavior change to the resolution logic; tests (32) and `prek -a` (ruff + mypy `--strict`) pass.

## Changes
- **`info.py`** — `EXTENDABLE_FIELDS` is exactly `ALL_FIELDS - SCALAR_FIELDS`, so define it that way instead of re-listing the non-scalar fields. Removes duplication and makes the "extendable = non-scalar" invariant impossible to desync.
- **`loader.py`** — raise `ValueError` (not `AssertionError`) for a non-existent `provider-path`; it's a user-config error and matches the other validations in the file.
- **`fancy_pypi_readme.py`** — import `Mapping` under `TYPE_CHECKING` (annotations are strings via `from __future__ import annotations`), and widen `settings` to `dict[str, object]` since the body requires it to be empty — matching `setuptools_scm.py`.
- **`toml_schema.json`** — fix `dynamic-metadata` → `dynamic_metadata` in the `$id` path (package dir uses an underscore).
- **`README.md`** — the regex example showed a regex that wasn't the actual default and the prose claimed it was; dropped the stale literal and corrected the description. Also documented the previously-undocumented `result` and `remove` settings.