### PR TITLE
docs: split README into Sphinx pages by audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,39 +17,12 @@ https://github.com/scikit-build/scikit-build-core/issues/230.
 >
 > This is still a WiP! The design may still change.
 
-## For users
-
+`dynamic-metadata` defines a plugin protocol that lets a Python build backend
+compute `[project]` fields (version, readme, dependencies, …) at build time.
 Plugins are configured as an **ordered array of tables**,
-`[[tool.dynamic-metadata]]`. Each entry must specify a `provider` exposing the
-API in the next section; everything else in the entry is passed to that plugin
-as settings. A `provider` is either a module (`"<module>"`) or a class within a
-module (`"<module>:<Class>"`); a class is instantiated and its hooks are called
-as methods.
+`[[tool.dynamic-metadata]]`, each naming a `provider`:
 
 ```toml
-[[tool.dynamic-metadata]]
-provider = "<module>"        # or "<module>:<Class>"
-# ... plugin settings ...
-```
-
-Entries run **in order**, so a later entry sees every field an earlier entry
-produced. This makes resolution order explicit (no dependency graph), lets you
-modify one field with several plugins, and means a plugin can read another
-field's value simply with `project[...]`.
-
-There is an optional key, `provider-path`, which specifies a local directory to
-load the plugin from, allowing plugins to live inside your own project. Plugins
-can, if desired, use their own `tool.*` sections as well.
-
-### Example: regex
-
-An example regex plugin is provided in this package. It is used like this:
-
-```toml
-[build-system]
-requires = ["...", "dynamic-metadata"]
-build-backend = "..."
-
 [project]
 dynamic = ["version"]
 
@@ -59,173 +32,24 @@ field = "version"
 input = "src/my_package/__init__.py"
 ```
 
-Since this plugin lives inside `dynamic-metadata`, you have to include that in
-your requirements. Make sure the field is marked dynamic in your project table.
-The settings are defined by the plugin; this one takes the target `field` and a
-required `input` file. The optional `regex` defaults to an expression that
-matches `__version__`/`VERSION` (with an optional `: str` annotation) and
-captures a `"value"` named group (`?P<value>`); supply your own to extract from
-a different pattern, keeping a `"value"` group. The optional `result` is a
-`str.format` template over the match (default `"{value}"`, with access to every
-numbered and named group), and `remove` is a regex stripped from the result.
+Your build backend _must support_ dynamic-metadata for this to work. Build
+backends known to support this currently include:
 
-### Mixing static and dynamic values (PEP 808)
+- scikit-build-core (1.0+)
 
-Following [PEP 808][], list and table fields can be given a static value in
-`[project]` _and_ listed in `dynamic` at the same time. A provider may only
-**add** to the static portion — it cannot remove, reorder, or change existing
-entries.
+The documentation is split by audience:
 
-```toml
-[project]
-dependencies = ["torch", "packaging"]
-dynamic = ["dependencies"]
+- **[For users](https://dynamic-metadata.readthedocs.io/en/latest/users.html)**
+  — configure plugins in `pyproject.toml`.
+- **[Bundled plugins](https://dynamic-metadata.readthedocs.io/en/latest/plugins.html)**
+  — the plugins shipped with this package (`regex`, `template`,
+  `setuptools_scm`, `fancy_pypi_readme`).
+- **[For plugin authors](https://dynamic-metadata.readthedocs.io/en/latest/plugin_authors.html)**
+  — implement the hooks; no runtime dependency on this package required.
+- **[For backend authors](https://dynamic-metadata.readthedocs.io/en/latest/backend_authors.html)**
+  — drive plugins from a build backend.
 
-[[tool.dynamic-metadata]]
-provider = "..."
-field = "dependencies"
-```
-
-The provider returns only its additions; the loader merges them onto the current
-value, with existing entries kept first and the provider's entries appended
-verbatim. A provider may read the value of any field already resolved (the
-static value of the field it is extending, or any field produced by an earlier
-entry) via `project[...]` to decide what to add; reading a field that has not
-been produced yet raises a `KeyError`. For tables (`urls`, `scripts`,
-`entry-points`, `optional-dependencies`, …) the provider may add keys but not
-change the value of an existing one.
-
-This add-only merge applies to every list/table field. The single-value fields
-(`version`, `description`, `requires-python`, `license`, and `readme`) cannot be
-extended, so they may not be both static and dynamic; a later entry targeting
-one of them instead **replaces** the value (a transform pipeline — for example,
-one plugin extracts a version and a later one normalizes it).
-
-[PEP 808]: https://peps.python.org/pep-0808/
-
-## For plugin authors
-
-**You do not need to depend on dynamic-metadata to write a plugin.** This
-library provides testing and static typing helpers that are not needed at
-runtime, along with a reference implementation that you can either use as an
-example, or use directly if you are fine to require the dependency.
-
-Like PEP 517's hooks, `dynamic-metadata` defines a set of hooks that you can
-implement; one required hook and three optional hooks. A provider is either a
-module exposing these hooks as functions, or a class (`"<module>:<Class>"`)
-exposing them as methods — a class is instantiated with no arguments, so its
-hooks share state through `self`. The required hook is:
-
-```python
-def dynamic_metadata(
-    settings: Mapping[str, Any],
-    project: Mapping[str, Any],
-) -> dict[str, Any]: ...  # return a fragment of [project], e.g. {"version": ...}
-```
-
-The hook returns a **dict** that is a fragment of the `[project]` table — a
-mapping of field name to value, such as `{"version": "1.2.3"}` or
-`{"dependencies": ["numpy"]}`. The framework merges it into the project. One
-plugin may set several fields at once, and every returned field must be listed
-in `[project].dynamic`.
-
-The hook no longer receives a `field` argument: a single-purpose plugin
-(`setuptools_scm`, `fancy_pypi_readme`) hardcodes which field it produces, while
-a generic plugin (`regex`, `template`) reads the target field from a `field`
-setting. `project` is a read-only mapping of the project as resolved so far;
-read another field's value with `project["version"]`. The backend calls this
-hook in the same directory as PEP 517's hooks.
-
-There are three optional hooks.
-
-A plugin can receive the current build state:
-
-```python
-def build_state(
-    build_state: str,
-) -> None: ...  # called before dynamic_metadata with the current build state
-```
-
-`build_state` is a string the backend supplies describing the current build. It
-must be one of scikit-build-core's five build states: `"sdist"`, `"wheel"`,
-`"editable"`, `"metadata_wheel"`, or `"metadata_editable"` (the latter two are
-the `prepare_metadata_for_build_*` phases). This hook is called once, before
-`dynamic_metadata`. A plugin may use it — for example to reuse a value already
-computed in an SDist's `PKG-INFO` instead of recomputing it for the wheel — by
-stashing it (typically on `self` in a class provider) for `dynamic_metadata` to
-read; a plugin that does not care simply omits this hook.
-
-A plugin can return METADATA 2.2 dynamic status:
-
-```python
-def dynamic_wheel(
-    settings: Mapping[str, Any],
-) -> dict[str, bool]: ...  # map each field set -> may it change from SDist to wheel?
-```
-
-It returns a map from each field this plugin sets to whether that field's value
-can change between the SDist and the wheel (the METADATA 2.2 feature). A field
-not present defaults to "false", and `"version"` must always be "false". This
-hook is called after the main hook, so you do not need to validate the input
-here.
-
-A plugin can also decide at runtime if it needs extra dependencies:
-
-```python
-def get_requires_for_dynamic_metadata(
-    settings: Mapping[str, Any],
-) -> list[str]: ...  # return list of packages to require
-```
-
-This is mostly used to provide wrappers for existing non-compatible plugins and
-for plugins that require a CLI tool that has an optional compiled component.
-
-### Example: regex
-
-Here is a simplified version of the regex plugin:
-
-```python
-def dynamic_metadata(
-    settings: Mapping[str, Any],
-    _project: Mapping[str, Any],
-) -> dict[str, Any]:
-    # Input validation
-    if settings.keys() - {"field", "input", "regex"}:
-        raise RuntimeError("Only 'field', 'input', and 'regex' settings allowed")
-    if "field" not in settings:
-        raise RuntimeError("Must contain the 'field' setting naming the target")
-    if "input" not in settings:
-        raise RuntimeError("Must contain the 'input' setting to perform a regex on")
-    if not all(isinstance(x, str) for x in settings.values()):
-        raise RuntimeError("All settings must be strings")
-
-    field = settings["field"]
-    # If not explicitly specified in the entry, the default regex below is used.
-    regex = settings.get(
-        "regex", r'(?i)^(__version__|VERSION) *= *([\'"])v?(?P<value>.+?)\2'
-    )
-
-    with Path(settings["input"]).open(encoding="utf-8") as f:
-        match = re.search(regex, f.read())
-
-    if not match:
-        raise RuntimeError(f"Couldn't find {regex!r} in {settings['input']}")
-
-    return {field: match.group("value")}
-```
-
-## For backend authors
-
-**You do not need to depend on dynamic-metadata to support plugins.** This
-library provides some helper functions you can use if you want, but you can
-implement them yourself following the standard provided or vendor the helper
-file (which will be tested and supported).
-
-Collect the array of `[[tool.dynamic-metadata]]` entries and process them in
-order: load each entry's `provider`, call its `dynamic_metadata` hook with a
-snapshot of the project resolved so far, and merge the returned fragment in.
-Because the order is explicit, there is no dependency graph to compute — see
-`src/dynamic_metadata/loader.py` for the reference loop.
+<!-- SPHINX-END -->
 
 <!-- prettier-ignore-start -->
 [actions-badge]:            https://github.com/scikit-build/dynamic-metadata/workflows/CI/badge.svg

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -58,4 +58,5 @@ Shared helpers that bundled and third-party plugins can reuse.
    :members:
    :undoc-members:
 ```
+
 </content>

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,61 @@
+# API reference
+
+```{eval-rst}
+.. module:: dynamic_metadata
+```
+
+## Loader
+
+The driver consumed by build backends.
+
+```{eval-rst}
+.. automodule:: dynamic_metadata.loader
+   :members:
+   :undoc-members:
+```
+
+### Plugin protocols
+
+The protocols a provider may implement. Every provider satisfies
+`DynamicMetadataProtocol`; the others add optional hooks.
+
+```{eval-rst}
+.. autoclass:: dynamic_metadata.loader.DynamicMetadataProtocol
+   :members:
+.. autoclass:: dynamic_metadata.loader.DynamicMetadataBuildStateProtocol
+   :members:
+.. autoclass:: dynamic_metadata.loader.DynamicMetadataRequirementsProtocol
+   :members:
+.. autoclass:: dynamic_metadata.loader.DynamicMetadataWheelProtocol
+   :members:
+```
+
+## Field taxonomy
+
+The single source of truth for which `[project]` fields can be dynamic and what
+shape their value has.
+
+```{eval-rst}
+.. automodule:: dynamic_metadata.info
+   :members:
+   :undoc-members:
+```
+
+## Plugin helpers
+
+Shared helpers that bundled and third-party plugins can reuse.
+
+```{eval-rst}
+.. automodule:: dynamic_metadata.plugins
+   :members:
+   :undoc-members:
+```
+
+## Schema
+
+```{eval-rst}
+.. automodule:: dynamic_metadata.schema
+   :members:
+   :undoc-members:
+```
+</content>

--- a/docs/backend_authors.md
+++ b/docs/backend_authors.md
@@ -1,0 +1,34 @@
+# For backend authors
+
+**You do not need to depend on dynamic-metadata to support plugins.** This library
+provides some helper functions you can use if you want, but you can implement them
+yourself following the standard provided or vendor the helper file (which will be
+tested and supported).
+
+Collect the array of `[[tool.dynamic-metadata]]` entries and process them in
+order: load each entry's `provider`, call its `dynamic_metadata` hook with a
+snapshot of the project resolved so far, and merge the returned fragment in.
+Because the order is explicit, there is no dependency graph to compute.
+
+The reference loop lives in {mod}`dynamic_metadata.loader`. Its entry point is:
+
+```python
+def process_dynamic_metadata(
+    project: Mapping[str, Any],
+    entries: list[dict[str, Any]],
+    build_state: str,
+) -> dict[str, Any]: ...
+```
+
+It builds a plain `dict` and applies entries in order. Each provider gets a
+read-only snapshot (a `MappingProxyType`) of the project resolved so far, so a
+later entry can read an earlier one's result with `project[...]`; a forward
+reference is just a `KeyError`, and cycles are structurally impossible. The
+returned fragment is merged per field: lists append, tables add keys (PEP 808
+add-only), and a single-value field is replaced if a later entry targets it. Each
+resolved field is removed from `dynamic`.
+
+See the [API reference](api/index.md) for the protocols (`DynamicMetadataProtocol`
+and its subclasses) and the field taxonomy in {mod}`dynamic_metadata.info` that
+the loader validates against.
+</content>

--- a/docs/backend_authors.md
+++ b/docs/backend_authors.md
@@ -1,9 +1,9 @@
 # For backend authors
 
-**You do not need to depend on dynamic-metadata to support plugins.** This library
-provides some helper functions you can use if you want, but you can implement them
-yourself following the standard provided or vendor the helper file (which will be
-tested and supported).
+**You do not need to depend on dynamic-metadata to support plugins.** This
+library provides some helper functions you can use if you want, but you can
+implement them yourself following the standard provided or vendor the helper
+file (which will be tested and supported).
 
 Collect the array of `[[tool.dynamic-metadata]]` entries and process them in
 order: load each entry's `provider`, call its `dynamic_metadata` hook with a
@@ -25,10 +25,9 @@ read-only snapshot (a `MappingProxyType`) of the project resolved so far, so a
 later entry can read an earlier one's result with `project[...]`; a forward
 reference is just a `KeyError`, and cycles are structurally impossible. The
 returned fragment is merged per field: lists append, tables add keys (PEP 808
-add-only), and a single-value field is replaced if a later entry targets it. Each
-resolved field is removed from `dynamic`.
+add-only), and a single-value field is replaced if a later entry targets it.
+Each resolved field is removed from `dynamic`.
 
-See the [API reference](api/index.md) for the protocols (`DynamicMetadataProtocol`
-and its subclasses) and the field taxonomy in {mod}`dynamic_metadata.info` that
-the loader validates against.
-</content>
+See the [API reference](api/index.md) for the protocols
+(`DynamicMetadataProtocol` and its subclasses) and the field taxonomy in
+{mod}`dynamic_metadata.info` that the loader validates against. </content>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,18 +28,28 @@ exclude_patterns = [
 ]
 
 html_theme = "furo"
+html_theme_options = {
+    "source_repository": "https://github.com/scikit-build/dynamic-metadata",
+    "source_branch": "main",
+    "source_directory": "docs/",
+}
 
 myst_enable_extensions = [
     "colon_fence",
+    "deflist",
+    "substitution",
 ]
+myst_heading_anchors = 2
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "packaging": ("https://packaging.python.org/en/latest", None),
 }
 
 nitpick_ignore = [
     ("py:class", "_io.StringIO"),
     ("py:class", "_io.BytesIO"),
+    ("py:data", "typing.Union"),
 ]
 
 always_document_param_types = True

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,31 @@
 # dynamic-metadata
 
-```{toctree}
-:maxdepth: 2
-:hidden:
-
-```
-
 ```{include} ../README.md
 :start-after: <!-- SPHINX-START -->
+:end-before: <!-- SPHINX-END -->
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Guide
+:hidden:
+
+users
+plugins
+plugin_authors
+backend_authors
+```
+
+```{toctree}
+:maxdepth: 1
+:caption: Reference
+:hidden:
+
+api/index
 ```
 
 ## Indices and tables
 
 - {ref}`genindex`
 - {ref}`modindex`
-- {ref}`search`
+- {ref}`search` </content> </invoke>

--- a/docs/plugin_authors.md
+++ b/docs/plugin_authors.md
@@ -1,0 +1,124 @@
+# For plugin authors
+
+**You do not need to depend on dynamic-metadata to write a plugin.** This library
+provides testing and static typing helpers that are not needed at runtime, along
+with a reference implementation that you can either use as an example, or use
+directly if you are fine to require the dependency.
+
+Like PEP 517's hooks, `dynamic-metadata` defines a set of hooks that you can
+implement; one required hook and three optional hooks. A provider is either a
+module exposing these hooks as functions, or a class (`"<module>:<Class>"`)
+exposing them as methods — a class is instantiated with no arguments, so its
+hooks share state through `self`.
+
+## The required hook
+
+```python
+def dynamic_metadata(
+    settings: Mapping[str, Any],
+    project: Mapping[str, Any],
+) -> dict[str, Any]: ...  # return a fragment of [project], e.g. {"version": ...}
+```
+
+The hook returns a **dict** that is a fragment of the `[project]` table — a
+mapping of field name to value, such as `{"version": "1.2.3"}` or
+`{"dependencies": ["numpy"]}`. The framework merges it into the project. One
+plugin may set several fields at once, and every returned field must be listed in
+`[project].dynamic`.
+
+The hook does not receive a `field` argument: a single-purpose plugin
+(`setuptools_scm`, `fancy_pypi_readme`) hardcodes which field it produces, while a
+generic plugin (`regex`, `template`) reads the target field from a `field`
+setting. `project` is a read-only mapping of the project as resolved so far; read
+another field's value with `project["version"]`. The backend calls this hook in
+the same directory as PEP 517's hooks.
+
+## Optional hooks
+
+There are three optional hooks.
+
+### Receiving the build state
+
+```python
+def build_state(
+    build_state: str,
+) -> None: ...  # called before dynamic_metadata with the current build state
+```
+
+`build_state` is a string the backend supplies describing the current build. It
+must be one of scikit-build-core's five build states: `"sdist"`, `"wheel"`,
+`"editable"`, `"metadata_wheel"`, or `"metadata_editable"` (the latter two are
+the `prepare_metadata_for_build_*` phases). This hook is called once, before
+`dynamic_metadata`. A plugin may use it — for example to reuse a value already
+computed in an SDist's `PKG-INFO` instead of recomputing it for the wheel — by
+stashing it (typically on `self` in a class provider) for `dynamic_metadata` to
+read; a plugin that does not care simply omits this hook.
+
+### METADATA 2.2 dynamic status
+
+```python
+def dynamic_wheel(
+    settings: Mapping[str, Any],
+) -> dict[str, bool]: ...  # map each field set -> may it change from SDist to wheel?
+```
+
+It returns a map from each field this plugin sets to whether that field's value
+can change between the SDist and the wheel (the METADATA 2.2 feature). A field not
+present defaults to "false", and `"version"` must always be "false". This hook is
+called after the main hook, so you do not need to validate the input here.
+
+### Extra build requirements
+
+```python
+def get_requires_for_dynamic_metadata(
+    settings: Mapping[str, Any],
+) -> list[str]: ...  # return list of packages to require
+```
+
+This is mostly used to provide wrappers for existing non-compatible plugins and
+for plugins that require a CLI tool that has an optional compiled component.
+
+## Example: regex
+
+Here is a simplified version of the regex plugin:
+
+```python
+def dynamic_metadata(
+    settings: Mapping[str, Any],
+    _project: Mapping[str, Any],
+) -> dict[str, Any]:
+    # Input validation
+    if settings.keys() - {"field", "input", "regex"}:
+        raise RuntimeError("Only 'field', 'input', and 'regex' settings allowed")
+    if "field" not in settings:
+        raise RuntimeError("Must contain the 'field' setting naming the target")
+    if "input" not in settings:
+        raise RuntimeError("Must contain the 'input' setting to perform a regex on")
+    if not all(isinstance(x, str) for x in settings.values()):
+        raise RuntimeError("All settings must be strings")
+
+    field = settings["field"]
+    # If not explicitly specified in the entry, the default regex below is used.
+    regex = settings.get(
+        "regex", r'(?i)^(__version__|VERSION) *= *([\'"])v?(?P<value>.+?)\2'
+    )
+
+    with Path(settings["input"]).open(encoding="utf-8") as f:
+        match = re.search(regex, f.read())
+
+    if not match:
+        raise RuntimeError(f"Couldn't find {regex!r} in {settings['input']}")
+
+    return {field: match.group("value")}
+```
+
+## Reusing the value-shaping helper
+
+A generic plugin should work for every field type, not just strings. The
+`dynamic_metadata.plugins._process_dynamic_metadata(field, action, result)`
+helper applies a string-transform `action` across whatever container shape the
+target `field` requires (a string, a list of strings, a table, a table of lists,
+…), validating the shape along the way. The bundled `regex` and `template`
+plugins call it so they only write the transform once. You are encouraged to
+reuse this helper or vendor it.
+</content>

--- a/docs/plugin_authors.md
+++ b/docs/plugin_authors.md
@@ -1,9 +1,9 @@
 # For plugin authors
 
-**You do not need to depend on dynamic-metadata to write a plugin.** This library
-provides testing and static typing helpers that are not needed at runtime, along
-with a reference implementation that you can either use as an example, or use
-directly if you are fine to require the dependency.
+**You do not need to depend on dynamic-metadata to write a plugin.** This
+library provides testing and static typing helpers that are not needed at
+runtime, along with a reference implementation that you can either use as an
+example, or use directly if you are fine to require the dependency.
 
 Like PEP 517's hooks, `dynamic-metadata` defines a set of hooks that you can
 implement; one required hook and three optional hooks. A provider is either a
@@ -23,15 +23,15 @@ def dynamic_metadata(
 The hook returns a **dict** that is a fragment of the `[project]` table — a
 mapping of field name to value, such as `{"version": "1.2.3"}` or
 `{"dependencies": ["numpy"]}`. The framework merges it into the project. One
-plugin may set several fields at once, and every returned field must be listed in
-`[project].dynamic`.
+plugin may set several fields at once, and every returned field must be listed
+in `[project].dynamic`.
 
 The hook does not receive a `field` argument: a single-purpose plugin
-(`setuptools_scm`, `fancy_pypi_readme`) hardcodes which field it produces, while a
-generic plugin (`regex`, `template`) reads the target field from a `field`
-setting. `project` is a read-only mapping of the project as resolved so far; read
-another field's value with `project["version"]`. The backend calls this hook in
-the same directory as PEP 517's hooks.
+(`setuptools_scm`, `fancy_pypi_readme`) hardcodes which field it produces, while
+a generic plugin (`regex`, `template`) reads the target field from a `field`
+setting. `project` is a read-only mapping of the project as resolved so far;
+read another field's value with `project["version"]`. The backend calls this
+hook in the same directory as PEP 517's hooks.
 
 ## Optional hooks
 
@@ -63,9 +63,10 @@ def dynamic_wheel(
 ```
 
 It returns a map from each field this plugin sets to whether that field's value
-can change between the SDist and the wheel (the METADATA 2.2 feature). A field not
-present defaults to "false", and `"version"` must always be "false". This hook is
-called after the main hook, so you do not need to validate the input here.
+can change between the SDist and the wheel (the METADATA 2.2 feature). A field
+not present defaults to "false", and `"version"` must always be "false". This
+hook is called after the main hook, so you do not need to validate the input
+here.
 
 ### Extra build requirements
 
@@ -120,5 +121,4 @@ helper applies a string-transform `action` across whatever container shape the
 target `field` requires (a string, a list of strings, a table, a table of lists,
 …), validating the shape along the way. The bundled `regex` and `template`
 plugins call it so they only write the transform once. You are encouraged to
-reuse this helper or vendor it.
-</content>
+reuse this helper or vendor it. </content>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -23,13 +23,13 @@ input = "src/my_package/__init__.py"
 
 Settings (all values must be strings):
 
-| Setting  | Required           | Description                                                                                                                                  |
-| -------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `field`  | yes                | The metadata field to set.                                                                                                                   |
-| `input`  | yes                | The file to read.                                                                                                                            |
-| `regex`  | unless version     | The pattern to search for. Must capture a `value` named group (`?P<value>`). Defaults to matching `__version__`/`VERSION` (optionally `: str`-annotated). |
-| `result` | no (`"{value}"`)   | A `str.format` template over the match, with access to every numbered and named group.                                                       |
-| `remove` | no                 | A regex stripped from the result.                                                                                                            |
+| Setting  | Required         | Description                                                                                                                                               |
+| -------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `field`  | yes              | The metadata field to set.                                                                                                                                |
+| `input`  | yes              | The file to read.                                                                                                                                         |
+| `regex`  | unless version   | The pattern to search for. Must capture a `value` named group (`?P<value>`). Defaults to matching `__version__`/`VERSION` (optionally `: str`-annotated). |
+| `result` | no (`"{value}"`) | A `str.format` template over the match, with access to every numbered and named group.                                                                    |
+| `remove` | no               | A regex stripped from the result.                                                                                                                         |
 
 The search runs in `re.MULTILINE` mode. When the target `field` is not a string
 field, `result` is applied across the container shape the field requires (each
@@ -49,9 +49,9 @@ result = "{project[name]} {project[version]}"
 
 Settings:
 
-| Setting  | Required | Description                                                              |
-| -------- | -------- | ------------------------------------------------------------------------ |
-| `field`  | yes      | The metadata field to set.                                               |
+| Setting  | Required | Description                                                               |
+| -------- | -------- | ------------------------------------------------------------------------- |
+| `field`  | yes      | The metadata field to set.                                                |
 | `result` | yes      | A `str.format` template; reference resolved fields with `{project[...]}`. |
 
 Only fields produced by earlier entries (or static values already in
@@ -77,8 +77,8 @@ provider = "dynamic_metadata.plugins.setuptools_scm"
 
 ## `fancy_pypi_readme`
 
-`dynamic_metadata.plugins.fancy_pypi_readme` wraps [hatch-fancy-pypi-readme][] to
-build a `readme`. It takes no inline settings; configure it through the
+`dynamic_metadata.plugins.fancy_pypi_readme` wraps [hatch-fancy-pypi-readme][]
+to build a `readme`. It takes no inline settings; configure it through the
 `[tool.hatch.metadata.hooks.fancy-pypi-readme]` table. The dependency
 (`hatch-fancy-pypi-readme>=22.3`) is declared via
 `get_requires_for_dynamic_metadata`. Substitutions can reference the resolved
@@ -98,4 +98,5 @@ content-type = "text/markdown"
 
 [setuptools-scm]: https://setuptools-scm.readthedocs.io
 [hatch-fancy-pypi-readme]: https://github.com/hynek/hatch-fancy-pypi-readme
+
 </content>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,101 @@
+# Bundled plugins
+
+This package ships a handful of plugins. Two are generic (they read their target
+from a `field` setting and can write any field), and two wrap external tools.
+Because they live inside `dynamic-metadata`, you must add `dynamic-metadata` to
+your `[build-system].requires` to use them.
+
+## `regex`
+
+`dynamic_metadata.plugins.regex` extracts a value from a file with a regular
+expression. By default it pulls a version out of a `__version__`/`VERSION`
+assignment.
+
+```toml
+[project]
+dynamic = ["version"]
+
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.regex"
+field = "version"
+input = "src/my_package/__init__.py"
+```
+
+Settings (all values must be strings):
+
+| Setting  | Required           | Description                                                                                                                                  |
+| -------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `field`  | yes                | The metadata field to set.                                                                                                                   |
+| `input`  | yes                | The file to read.                                                                                                                            |
+| `regex`  | unless version     | The pattern to search for. Must capture a `value` named group (`?P<value>`). Defaults to matching `__version__`/`VERSION` (optionally `: str`-annotated). |
+| `result` | no (`"{value}"`)   | A `str.format` template over the match, with access to every numbered and named group.                                                       |
+| `remove` | no                 | A regex stripped from the result.                                                                                                            |
+
+The search runs in `re.MULTILINE` mode. When the target `field` is not a string
+field, `result` is applied across the container shape the field requires (each
+string in a list, each value in a table, and so on).
+
+## `template`
+
+`dynamic_metadata.plugins.template` fills a `str.format` template from fields
+resolved by earlier entries, demonstrating cross-field references.
+
+```toml
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.template"
+field = "readme"
+result = "{project[name]} {project[version]}"
+```
+
+Settings:
+
+| Setting  | Required | Description                                                              |
+| -------- | -------- | ------------------------------------------------------------------------ |
+| `field`  | yes      | The metadata field to set.                                               |
+| `result` | yes      | A `str.format` template; reference resolved fields with `{project[...]}`. |
+
+Only fields produced by earlier entries (or static values already in
+`[project]`) are available — a forward reference raises a `KeyError`.
+
+## `setuptools_scm`
+
+`dynamic_metadata.plugins.setuptools_scm` wraps [setuptools-scm][] to derive the
+version from your version control system. It takes no inline settings; configure
+it through setuptools-scm's own `[tool.setuptools_scm]` table. The dependency is
+declared via `get_requires_for_dynamic_metadata`, so the backend installs it
+automatically.
+
+```toml
+[project]
+dynamic = ["version"]
+
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.setuptools_scm"
+
+[tool.setuptools_scm]
+```
+
+## `fancy_pypi_readme`
+
+`dynamic_metadata.plugins.fancy_pypi_readme` wraps [hatch-fancy-pypi-readme][] to
+build a `readme`. It takes no inline settings; configure it through the
+`[tool.hatch.metadata.hooks.fancy-pypi-readme]` table. The dependency
+(`hatch-fancy-pypi-readme>=22.3`) is declared via
+`get_requires_for_dynamic_metadata`. Substitutions can reference the resolved
+`version`, so place this entry after the one that produces it.
+
+```toml
+[project]
+dynamic = ["readme"]
+
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.fancy_pypi_readme"
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+# ... fragments and substitutions ...
+```
+
+[setuptools-scm]: https://setuptools-scm.readthedocs.io
+[hatch-fancy-pypi-readme]: https://github.com/hynek/hatch-fancy-pypi-readme
+</content>

--- a/docs/users.md
+++ b/docs/users.md
@@ -47,8 +47,8 @@ input = "src/my_package/__init__.py"
 
 Since this plugin lives inside `dynamic-metadata`, you have to include that in
 your requirements. Make sure the field is marked dynamic in your project table.
-The settings are defined by the plugin; see [Bundled plugins](plugins.md) for the
-full list of settings each one accepts.
+The settings are defined by the plugin; see [Bundled plugins](plugins.md) for
+the full list of settings each one accepts.
 
 ## Mixing static and dynamic values (PEP 808)
 
@@ -69,19 +69,20 @@ field = "dependencies"
 
 The provider returns only its additions; the loader merges them onto the current
 value, with existing entries kept first and the provider's entries appended
-verbatim. A provider may read the value of any field already resolved (the static
-value of the field it is extending, or any field produced by an earlier entry)
-via `project[...]` to decide what to add; reading a field that has not been
-produced yet raises a `KeyError`. For tables (`urls`, `scripts`, `entry-points`,
-`optional-dependencies`, …) the provider may add keys but not change the value of
-an existing one.
+verbatim. A provider may read the value of any field already resolved (the
+static value of the field it is extending, or any field produced by an earlier
+entry) via `project[...]` to decide what to add; reading a field that has not
+been produced yet raises a `KeyError`. For tables (`urls`, `scripts`,
+`entry-points`, `optional-dependencies`, …) the provider may add keys but not
+change the value of an existing one.
 
 This add-only merge applies to every list/table field. The single-value fields
 (`version`, `description`, `requires-python`, `license`, and `readme`) cannot be
-extended, so they may not be both static and dynamic; a later entry targeting one
-of them instead **replaces** the value (a transform pipeline — for example, one
-plugin extracts a version and a later one normalizes it).
+extended, so they may not be both static and dynamic; a later entry targeting
+one of them instead **replaces** the value (a transform pipeline — for example,
+one plugin extracts a version and a later one normalizes it).
 
 [PEP 808]: https://peps.python.org/pep-0808/
+
 </content>
 </invoke>

--- a/docs/users.md
+++ b/docs/users.md
@@ -1,0 +1,87 @@
+# For users
+
+Plugins are configured as an **ordered array of tables**,
+`[[tool.dynamic-metadata]]`. Each entry must specify a `provider` exposing the
+plugin API; everything else in the entry is passed to that plugin as settings. A
+`provider` is either a module (`"<module>"`) or a class within a module
+(`"<module>:<Class>"`); a class is instantiated and its hooks are called as
+methods.
+
+```toml
+[[tool.dynamic-metadata]]
+provider = "<module>"        # or "<module>:<Class>"
+# ... plugin settings ...
+```
+
+Entries run **in order**, so a later entry sees every field an earlier entry
+produced. This makes resolution order explicit (no dependency graph), lets you
+modify one field with several plugins, and means a plugin can read another
+field's value simply with `project[...]`.
+
+There is an optional key, `provider-path`, which specifies a local directory to
+load the plugin from, allowing plugins to live inside your own project. Plugins
+can, if desired, use their own `tool.*` sections as well.
+
+Your build backend _must support_ dynamic-metadata for this to work. Build
+backends known to support this currently include:
+
+- scikit-build-core (1.0+)
+
+## Example: regex
+
+An example regex plugin is provided in this package. It is used like this:
+
+```toml
+[build-system]
+requires = ["...", "dynamic-metadata"]
+build-backend = "..."
+
+[project]
+dynamic = ["version"]
+
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.regex"
+field = "version"
+input = "src/my_package/__init__.py"
+```
+
+Since this plugin lives inside `dynamic-metadata`, you have to include that in
+your requirements. Make sure the field is marked dynamic in your project table.
+The settings are defined by the plugin; see [Bundled plugins](plugins.md) for the
+full list of settings each one accepts.
+
+## Mixing static and dynamic values (PEP 808)
+
+Following [PEP 808][], list and table fields can be given a static value in
+`[project]` _and_ listed in `dynamic` at the same time. A provider may only
+**add** to the static portion — it cannot remove, reorder, or change existing
+entries.
+
+```toml
+[project]
+dependencies = ["torch", "packaging"]
+dynamic = ["dependencies"]
+
+[[tool.dynamic-metadata]]
+provider = "..."
+field = "dependencies"
+```
+
+The provider returns only its additions; the loader merges them onto the current
+value, with existing entries kept first and the provider's entries appended
+verbatim. A provider may read the value of any field already resolved (the static
+value of the field it is extending, or any field produced by an earlier entry)
+via `project[...]` to decide what to add; reading a field that has not been
+produced yet raises a `KeyError`. For tables (`urls`, `scripts`, `entry-points`,
+`optional-dependencies`, …) the provider may add keys but not change the value of
+an existing one.
+
+This add-only merge applies to every list/table field. The single-value fields
+(`version`, `description`, `requires-python`, `license`, and `readme`) cannot be
+extended, so they may not be both static and dynamic; a later entry targeting one
+of them instead **replaces** the value (a transform pipeline — for example, one
+plugin extracts a version and a later one normalizes it).
+
+[PEP 808]: https://peps.python.org/pep-0808/
+</content>
+</invoke>

--- a/noxfile.py
+++ b/noxfile.py
@@ -93,25 +93,6 @@ def docs(session: nox.Session) -> None:
 
 
 @nox.session(default=False)
-def build_api_docs(session: nox.Session) -> None:
-    """
-    Build (regenerate) API docs.
-    """
-
-    session.install("sphinx")
-    session.chdir("docs")
-    session.run(
-        "sphinx-apidoc",
-        "-o",
-        "api/",
-        "--module-first",
-        "--no-toc",
-        "--force",
-        "../src/dynamic_metadata",
-    )
-
-
-@nox.session(default=False)
 def build(session: nox.Session) -> None:
     """
     Build an SDist and wheel.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Sets up proper documentation instead of a single big README, following [scikit-build-core's docs layout](https://github.com/scikit-build/scikit-build-core).

## What changed

- **README.md** — trimmed to badges + a concise overview between `SPHINX-START`/`SPHINX-END` markers, a minimal toml example, the supported-backends list, and links into the doc sections.
- **docs/** — split the old single-page README include into pages mirroring the three-audience structure:
  - `index.md` — landing page (includes the README overview) + grouped toctrees (Guide / Reference)
  - `users.md` — configuring `[[tool.dynamic-metadata]]`, the regex example, PEP 808 mixing
  - `plugins.md` — reference for the bundled `regex`, `template`, `setuptools_scm`, `fancy_pypi_readme` plugins (settings sourced from the code)
  - `plugin_authors.md` — the required + three optional hooks and the `_process_dynamic_metadata` helper
  - `backend_authors.md` — the `process_dynamic_metadata` loop
  - `api/index.md` — autodoc reference for `loader` (incl. the four plugin protocols), `info`, `plugins`, `schema`
- **docs/conf.py** — Furo `source_repository`/`source_branch`/`source_directory`, `deflist`+`substitution` MyST extensions, `myst_heading_anchors`, a `packaging` intersphinx target, and a `typing.Union` nitpick ignore.
- **noxfile.py** — dropped the now-unused `build_api_docs` (sphinx-apidoc) session; the API page uses explicit `automodule`/`autoclass` directives instead.

## Notes

- The README's doc links point at `dynamic-metadata.readthedocs.io/en/latest/...`; those resolve once published to RTD.
- `nox -s docs` builds cleanly under nitpicky mode with warnings-as-errors; `prek -a` passes.