### PR TITLE
ci: add Python 3.15 to test matrix and classifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
             runs-on: ubuntu-latest
           - python-version: "3.14t"
             runs-on: ubuntu-latest
+          - python-version: "3.15"
+            runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds Python 3.15 to the CI matrix and the `[project]` classifiers.

- `pyproject.toml`: new `Programming Language :: Python :: 3.15` classifier
- `.github/workflows/ci.yml`: `3.15` entry in the `checks` matrix `include` list (`allow-prereleases: true` is already set, so the prerelease resolves)