### PR TITLE
build: switch to flit-core and add check-sdist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,14 @@ repos:
           - pytest<9 # Python 3.10
           - tomli
 
+  - repo: https://github.com/henryiii/check-sdist
+    rev: "v1.5.0"
+    hooks:
+      - id: check-sdist
+        args: [--inject-junk]
+        additional_dependencies:
+          - flit-core
+
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.2"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit-core >=3.11"]
+build-backend = "flit_core.buildapi"
 
 
 [project]
@@ -44,6 +44,20 @@ Changelog = "https://github.com/scikit-build/dynamic-metadata/releases"
 [project.entry-points."validate_pyproject.tool_schema"]
 dynamic-metadata = "dynamic_metadata.schema:get_schema"
 
+[tool.flit.sdist]
+include = ["tests/**/*.py"]
+exclude = ["**/*.egg-info"]
+
+[tool.check-sdist]
+git-only = [
+  ".git_archival.txt",
+  ".gitattributes",
+  ".gitignore",
+  "AGENTS.md",
+  "docs/",
+  "uv.lock",
+]
+
 [dependency-groups]
 test = [
   "pytest >=7",
@@ -58,10 +72,6 @@ docs = [
   "sphinx_autodoc_typehints",
   "furo",
 ]
-
-[tool.hatch]
-version.path = "src/dynamic_metadata/__init__.py"
-
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ Changelog = "https://github.com/scikit-build/dynamic-metadata/releases"
 dynamic-metadata = "dynamic_metadata.schema:get_schema"
 
 [tool.flit.sdist]
-include = ["tests/**/*.py"]
-exclude = ["**/*.egg-info"]
+include = ["tests/**/*.py", "docs/"]
+exclude = ["**/*.egg-info", "docs/_build"]
 
 [tool.check-sdist]
 git-only = [
@@ -55,7 +55,6 @@ git-only = [
   ".gitattributes",
   ".gitignore",
   "AGENTS.md",
-  "docs/",
   "uv.lock",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,13 @@ authors = [
 ]
 description = "This project is intended to document dynamic-metadata support."
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

- Move the build backend from **hatchling** to **flit-core** (`flit_core.buildapi`).
  - flit reads the version straight from `__version__` in `src/dynamic_metadata/__init__.py` (the existing `dynamic = ["version"]`) and auto-discovers the `src/` layout, so `[tool.hatch]` is dropped with no replacement config needed.
- Add the **check-sdist** pre-commit hook (`henryiii/check-sdist`, `--inject-junk`) to guard sdist contents.
- Modernize the license to **PEP 639**: an SPDX `license` expression plus `license-files`, replacing the deprecated license classifier.

## License (PEP 639)

```toml
license = "Apache-2.0"
license-files = ["LICENSE"]
```

The Apache classifier is removed; flit-core emits `Metadata-Version: 2.4` with `License-Expression: Apache-2.0` and `License-File: LICENSE`.

## sdist contents

flit-core builds sdists from the filesystem rather than VCS, so the config makes the include set explicit:

```toml
[tool.flit.sdist]
include = ["tests/**/*.py", "docs/"]
exclude = ["**/*.egg-info", "docs/_build"]

[tool.check-sdist]
git-only = [
  ".git_archival.txt",
  ".gitattributes",
  ".gitignore",
  "AGENTS.md",
  "uv.lock",
]
```

- Ships the package (incl. `py.typed` and `resources/toml_schema.json`), `tests/**/*.py`, and the `docs/` sources so downstream redistributors can run the suite and rebuild the docs.
- `**/*.egg-info` (test-run artifacts) and `docs/_build` (built HTML) are excluded from the filesystem walk.
- Dev-only tracked files are recorded as `git-only`. check-sdist's default-ignore already covers `.github`, `.pre-commit-config.yaml`, `.readthedocs.yml`, and `noxfile.py`.

## Verification

- `check-sdist --inject-junk` → **SDist matches git**
- `prek -a` clean; `pytest` → 34 passed
- `uv build` produces a wheel/sdist at version 0.1.0, Metadata 2.4, with package data, tests, and docs included