### PR TITLE
feat: add `dynamic-metadata show` CLI

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -50,6 +50,22 @@ your requirements. Make sure the field is marked dynamic in your project table.
 The settings are defined by the plugin; see [Bundled plugins](plugins.md) for
 the full list of settings each one accepts.
 
+## Inspecting the result
+
+Installing `dynamic-metadata` provides a `dynamic-metadata` command (also
+runnable as `python -m dynamic_metadata`) for previewing what your plugins
+produce, without invoking the build backend:
+
+```console
+$ dynamic-metadata show
+```
+
+`show` reads `pyproject.toml` from the current directory, runs the configured
+`[[tool.dynamic-metadata]]` entries in order, and prints the resolved
+`[project]` table as JSON. Use `--pyproject-toml PATH` to point at another file
+and `--state` to choose the build state passed to plugins (default
+`metadata_wheel`).
+
 ## Mixing static and dynamic values (PEP 808)
 
 Following [PEP 808][], list and table fields can be given a static value in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,11 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "typing_extensions >=4.6; python_version<'3.11'",
+  "tomli >=1.1; python_version<'3.11'",
 ]
+
+[project.scripts]
+dynamic-metadata = "dynamic_metadata.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/scikit-build/dynamic-metadata"
@@ -142,6 +146,7 @@ isort.required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]
 "noxfile.py" = ["T20"]
+"src/dynamic_metadata/__main__.py" = ["T20"]  # CLI prints to stdout
 "src/dynamic_metadata/plugins/*" = ["PLC0415"]  # plugins lazy-import optional deps
 
 

--- a/src/dynamic_metadata/__main__.py
+++ b/src/dynamic_metadata/__main__.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from ._compat import tomllib
+from .loader import BUILD_STATES, process_dynamic_metadata
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .loader import BuildState
+
+__all__ = ["main"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def main_show(args: argparse.Namespace, /) -> None:
+    """Print the project table with dynamic metadata resolved, as JSON."""
+    with Path(args.pyproject_toml).open("rb") as f:
+        pyproject = tomllib.load(f)
+
+    project = pyproject.get("project", {})
+    entries = pyproject.get("tool", {}).get("dynamic-metadata", [])
+    if entries:
+        project = process_dynamic_metadata(
+            project, entries, cast("BuildState", args.state)
+        )
+    print(json.dumps(project, indent=2))
+
+
+def populate_parser(parser: argparse.ArgumentParser, /) -> None:
+    """Add the ``dynamic-metadata`` subcommands to an existing parser."""
+    subparsers = parser.add_subparsers(required=True, help="Commands")
+    show = subparsers.add_parser(
+        "show",
+        help="Show the project table with dynamic metadata resolved",
+        description="Reads pyproject.toml, runs the configured "
+        "[[tool.dynamic-metadata]] plugins in order, and prints the resulting "
+        "[project] table as JSON.",
+    )
+    show.set_defaults(func=main_show)
+    show.add_argument(
+        "--pyproject-toml",
+        default="pyproject.toml",
+        help="Path to the pyproject.toml to read (default: ./pyproject.toml)",
+    )
+    show.add_argument(
+        "--state",
+        choices=sorted(BUILD_STATES),
+        default="metadata_wheel",
+        help="The build state to resolve metadata for (default: metadata_wheel)",
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="dynamic-metadata",
+        allow_abbrev=False,
+        description="dynamic-metadata command line interface.",
+    )
+    populate_parser(parser)
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+import dynamic_metadata.__main__
 import dynamic_metadata.loader
 import dynamic_metadata.plugins
 
@@ -520,3 +522,79 @@ def test_actions(field: str, input: Any, output: Any) -> None:
         field, lambda x: x.format(sub=42), input
     )
     assert output == result
+
+
+def test_cli_show(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\n"
+        'name = "test"\n'
+        'version = "0.1.0"\n'
+        'dynamic = ["requires-python"]\n'
+        "\n"
+        "[[tool.dynamic-metadata]]\n"
+        'provider = "dynamic_metadata.plugins.template"\n'
+        'field = "requires-python"\n'
+        'result = ">={project[version]}"\n'
+    )
+
+    dynamic_metadata.__main__.main(["show", "--pyproject-toml", str(pyproject)])
+
+    project = json.loads(capsys.readouterr().out)
+    assert project == {
+        "name": "test",
+        "version": "0.1.0",
+        "requires-python": ">=0.1.0",
+        "dynamic": [],
+    }
+
+
+def test_cli_show_no_entries(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # With no [[tool.dynamic-metadata]] entries the static project table is
+    # printed verbatim.
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"\n')
+
+    dynamic_metadata.__main__.main(["show", "--pyproject-toml", str(pyproject)])
+
+    project = json.loads(capsys.readouterr().out)
+    assert project == {"name": "test", "version": "0.1.0"}
+
+
+def test_cli_show_state(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # --state is forwarded to the build_state hook.
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "state_prov.py").write_text(
+        "class Provider:\n"
+        "    def build_state(self, build_state):\n"
+        "        self.build_state = build_state\n"
+        "    def dynamic_metadata(self, settings, project):\n"
+        "        return {'version': self.build_state}\n"
+    )
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\n"
+        'name = "test"\n'
+        'dynamic = ["version"]\n'
+        "\n"
+        "[[tool.dynamic-metadata]]\n"
+        'provider = "state_prov:Provider"\n'
+        f"provider-path = {json.dumps(str(plugin_dir))}\n"
+    )
+
+    dynamic_metadata.__main__.main(
+        ["show", "--pyproject-toml", str(pyproject), "--state", "sdist"]
+    )
+
+    project = json.loads(capsys.readouterr().out)
+    assert project["version"] == "sdist"

--- a/uv.lock
+++ b/uv.lock
@@ -617,6 +617,7 @@ wheels = [
 name = "dynamic-metadata"
 source = { editable = "." }
 dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
 ]
@@ -657,7 +658,10 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.6" }]
+requires-dist = [
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.6" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds a CLI for previewing resolved dynamic metadata, mirroring scikit-build-core's `python -m scikit_build_core build project-table` with the same JSON output.

`dynamic-metadata show` reads `pyproject.toml`, runs the configured `[[tool.dynamic-metadata]]` entries in order via `process_dynamic_metadata`, and prints the resolved `[project]` table as JSON.

```console
$ dynamic-metadata show
```

## Details

- **`src/dynamic_metadata/__main__.py`** (new) — `populate_parser`/`main` structure (like scikit-build-core, so more subcommands can be added later). Runs as the `dynamic-metadata` console script and as `python -m dynamic_metadata`.
  - `--pyproject-toml PATH` — file to read (default `./pyproject.toml`)
  - `--state` — build state passed to plugins' `build_state` hook (choices from `BUILD_STATES`, default `metadata_wheel`)
- **`pyproject.toml`** — adds the `[project.scripts]` entry, and `tomli >=1.1; python_version<'3.11'` so the `_compat.tomllib` shim is satisfied on 3.8–3.10. Adds a `T20` ruff per-file-ignore for `__main__.py` (the CLI prints).
- **Tests** — cover the template plugin resolving a field, the no-entries passthrough, and `--state` reaching the `build_state` hook.
- **`docs/users.md`** — new "Inspecting the result" section.

## Note

`--state` defaults to `metadata_wheel` since `show` previews metadata without a real build. The newer `process_dynamic_metadata` requires a `build_state` argument (scikit-build-core's older `project-table` doesn't pass one), so the output shape matches but with an explicit state knob.