### PR TITLE
docs: document custom plugins with provider-path

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -58,5 +58,3 @@ Shared helpers that bundled and third-party plugins can reuse.
    :members:
    :undoc-members:
 ```
-
-</content>

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,4 +28,4 @@ api/index
 
 - {ref}`genindex`
 - {ref}`modindex`
-- {ref}`search` </content> </invoke>
+- {ref}`search`

--- a/docs/plugin_authors.md
+++ b/docs/plugin_authors.md
@@ -120,5 +120,5 @@ A generic plugin should work for every field type, not just strings. The
 helper applies a string-transform `action` across whatever container shape the
 target `field` requires (a string, a list of strings, a table, a table of lists,
 …), validating the shape along the way. The bundled `regex` and `template`
-plugins call it so they only write the transform once. You are encouraged to
-reuse this helper or vendor it. </content>
+plugins call it so they only write the transform once. You are encouraged to do
+something similar.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -55,5 +55,3 @@ Settings:
 
 Only fields produced by earlier entries (or static values already in
 `[project]`) are available — a forward reference raises a `KeyError`.
-
-</content>

--- a/docs/users.md
+++ b/docs/users.md
@@ -139,6 +139,3 @@ one of them instead **replaces** the value (a transform pipeline — for example
 one plugin extracts a version and a later one normalizes it).
 
 [PEP 808]: https://peps.python.org/pep-0808/
-
-</content>
-</invoke>

--- a/docs/users.md
+++ b/docs/users.md
@@ -50,6 +50,46 @@ your requirements. Make sure the field is marked dynamic in your project table.
 The settings are defined by the plugin; see [Bundled plugins](plugins.md) for
 the full list of settings each one accepts.
 
+## Providing a custom plugin
+
+You don't have to publish a plugin, or even put it in an installed package, to
+use one. The optional `provider-path` key names a local directory to import the
+`provider` module from, so a plugin can live right inside your project alongside
+`pyproject.toml`. A provider loaded this way needs no runtime dependency on
+`dynamic-metadata` — it just has to expose the [hooks](plugin_authors.md).
+
+Drop a module in your project — say `scripts/my_plugin.py`:
+
+```python
+def dynamic_metadata(settings, project):
+    return {"version": "1.2.3"}
+```
+
+and point an entry at it with `provider-path`:
+
+```toml
+[project]
+dynamic = ["version"]
+
+[[tool.dynamic-metadata]]
+provider = "my_plugin"
+provider-path = "scripts"
+```
+
+`provider` is still the module name (`my_plugin`, the file without its `.py`),
+and `provider-path` is the directory to find it in (relative to
+`pyproject.toml`). It must be an existing directory, and it is searched in
+isolation: a module of the same name reachable elsewhere on `sys.path` will not
+shadow or substitute for one missing from `provider-path`. A
+`"<module>:<Class>"` provider works the same way — the class is imported from
+`provider-path` and instantiated.
+
+Because the module is imported, make sure any third-party packages it needs are
+available at build time. If they aren't already pulled in by your build backend,
+list them in `[build-system].requires`, or have the plugin declare them from its
+`get_requires_for_dynamic_metadata` hook (see
+[plugin authors](plugin_authors.md)).
+
 ## Inspecting the result
 
 Installing `dynamic-metadata` provides a `dynamic-metadata` command (also


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a **"Providing a custom plugin"** section to the user guide (`docs/users.md`), between the regex example and "Inspecting the result".

It shows how to load a provider that lives inside your own project via `provider-path`, covering:

- A minimal worked example: a local `scripts/my_plugin.py` module plus the matching `[[tool.dynamic-metadata]]` entry.
- The semantics from `loader.py`: `provider` is the module name (file without `.py`), `provider-path` is the directory (relative to `pyproject.toml`), it must be an existing directory, and it is searched in isolation (no `sys.path` shadowing). `"<module>:<Class>"` providers work the same way.
- A note on making the plugin's own build-time dependencies available (`[build-system].requires` or `get_requires_for_dynamic_metadata`), with cross-links to the plugin-authors page.

Docs build cleanly via `nox -s docs`; `prek -a` passes.