### PR TITLE
feat: add static plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The documentation is split by audience:
 - **[For users](https://dynamic-metadata.readthedocs.io/en/latest/users.html)**
   — configure plugins in `pyproject.toml`.
 - **[Bundled plugins](https://dynamic-metadata.readthedocs.io/en/latest/plugins.html)**
-  — the plugins shipped with this package (`regex`, `template`, `fragment`,
-  `substitute`).
+  — the plugins shipped with this package (`regex`, `template`, `static`,
+  `fragment`, `substitute`).
 - **[For plugin authors](https://dynamic-metadata.readthedocs.io/en/latest/plugin_authors.html)**
   — implement the hooks; no runtime dependency on this package required.
 - **[For backend authors](https://dynamic-metadata.readthedocs.io/en/latest/backend_authors.html)**

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,10 +1,10 @@
 # Bundled plugins
 
-This package ships four plugins. `regex`, `template`, and `substitute` are
-generic — they read their target from a `field` setting. `readme_fragment` is
-single-purpose and always writes `readme`. Because they live inside
-`dynamic-metadata`, you must add `dynamic-metadata` to your
-`[build-system].requires` to use them.
+This package ships five plugins. `regex`, `template`, and `substitute` are
+generic — they read their target from a `field` setting. `static` writes values
+straight from its settings, and `readme_fragment` is single-purpose and always
+writes `readme`. Because they live inside `dynamic-metadata`, you must add
+`dynamic-metadata` to your `[build-system].requires` to use them.
 
 Entries run in order and each sees the project resolved so far, so several
 entries can cooperate on one field: `readme_fragment` and `substitute` build a
@@ -64,6 +64,49 @@ Settings:
 
 Only fields produced by earlier entries (or static values already in
 `[project]`) are available — a forward reference raises a `KeyError`.
+
+## `static`
+
+`dynamic_metadata.plugins.static` sets fields directly from its own settings —
+an alternative to writing them in `[project]`. Each setting is a metadata field
+mapped to its value, returned verbatim.
+
+```toml
+[project]
+dynamic = ["version", "description"]
+
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.static"
+version = "1.2.3"
+description = "My package"
+```
+
+Settings: any settable metadata field maps to the value to give it. The fields
+must be listed in `project.dynamic` like every dynamic field, and values use the
+same shape they would in `[project]` — a string for `version`, a list for
+`keywords`, a table for `readme`, and so on.
+
+This is mainly useful as the first half of a pipeline: it gives a later entry
+like `substitute` a _dynamic_ value to transform, which a field set in
+`[project]` cannot be (a scalar field may not be both static and dynamic).
+
+```toml
+[project]
+dynamic = ["version"]
+
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.static"
+version = "1.2.3-beta"
+
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.substitute"
+field = "version"
+pattern = "-beta$"
+replacement = "b0"
+```
+
+It can also keep metadata out of `[project]`, hiding it from tools that read
+`[project]` directly.
 
 ## `readme_fragment`
 

--- a/src/dynamic_metadata/plugins/static.py
+++ b/src/dynamic_metadata/plugins/static.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ["dynamic_metadata"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def dynamic_metadata(
+    settings: Mapping[str, Any],
+    _project: Mapping[str, Any],
+) -> dict[str, Any]:
+    # An alternative to writing the values in [project]: each setting is a
+    # metadata field returned verbatim. The loader validates the field names and
+    # their presence in `dynamic`. This gives a later entry (e.g. substitute) a
+    # *dynamic* value to transform, and keeps the values out of [project].
+    return dict(settings)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -916,3 +916,73 @@ def test_substitute_rejects_unknown_setting() -> None:
             ],
             "wheel",
         )
+
+
+def test_static_sets_fields() -> None:
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["version", "description", "keywords"]},
+        [
+            {
+                "provider": "dynamic_metadata.plugins.static",
+                "version": "1.2.3",
+                "description": "My package",
+                "keywords": ["a", "b"],
+            }
+        ],
+        "wheel",
+    )
+
+    assert pyproject["version"] == "1.2.3"
+    assert pyproject["description"] == "My package"
+    assert pyproject["keywords"] == ["a", "b"]
+    assert pyproject["dynamic"] == []
+
+
+def test_static_then_substitute() -> None:
+    # The main use: static gives substitute a dynamic value to transform.
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["version"]},
+        [
+            {
+                "provider": "dynamic_metadata.plugins.static",
+                "version": "1.2.3-beta",
+            },
+            {
+                "provider": "dynamic_metadata.plugins.substitute",
+                "field": "version",
+                "pattern": "-beta$",
+                "replacement": "b0",
+            },
+        ],
+        "wheel",
+    )
+
+    assert pyproject["version"] == "1.2.3b0"
+
+
+def test_static_rejects_unknown_field() -> None:
+    with pytest.raises(KeyError, match="not a settable dynamic-metadata field"):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": ["version"]},
+            [
+                {
+                    "provider": "dynamic_metadata.plugins.static",
+                    "descriptions": "typo",
+                }
+            ],
+            "wheel",
+        )
+
+
+def test_static_field_must_be_dynamic() -> None:
+    with pytest.raises(KeyError, match=r"must be listed in project\.dynamic"):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": []},
+            [
+                {
+                    "provider": "dynamic_metadata.plugins.static",
+                    "version": "1.2.3",
+                }
+            ],
+            "wheel",
+        )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a `static` plugin: an alternative to writing fields in `[project]`.

## What it does

`dynamic_metadata.plugins.static` returns its settings verbatim as a `[project]` fragment. It's a thin passthrough — the loader already validates field names against `ALL_FIELDS` and enforces that each is listed in `project.dynamic`.

Two intended uses:

- **Feeding a transform pipeline** — gives a later entry like `substitute` a *dynamic* value to modify, which a `[project]` value can't be (a scalar field may not be both static and dynamic per PEP 808).
- **Hiding metadata** from tools that read `[project]` directly.

```toml
[project]
dynamic = ["version"]

[[tool.dynamic-metadata]]
provider = "dynamic_metadata.plugins.static"
version = "1.2.3-beta"

[[tool.dynamic-metadata]]
provider = "dynamic_metadata.plugins.substitute"
field = "version"
pattern = "-beta$"
replacement = "b0"
```

## Design note

`static` is a pure passthrough rather than shape-validating values. This keeps it faithful to "an alternative to `[project]`" — e.g. it allows a string `readme` (a path), which `[project]` permits. No schema change needed; `toml_schema.json` already allows arbitrary per-entry properties.

## Changes

- `src/dynamic_metadata/plugins/static.py` — new plugin
- `docs/plugins.md` — new `static` section (four → five plugins)
- `README.md` — added `static` to the bundled-plugins list
- `tests/test_package.py` — 4 new tests (multi-field set, static→substitute pipeline, unknown-field rejection, must-be-dynamic check)

All 59 tests pass; `prek -a` (ruff, mypy, check-sdist, …) is clean.