### PR TITLE
feat: add opt-in `format` setting to substitute plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -169,12 +169,31 @@ replacement = "[#\\1](https://github.com/org/repo/issues/\\1)"
 
 Settings:
 
-| Setting       | Required     | Description                                                 |
-| ------------- | ------------ | ----------------------------------------------------------- |
-| `field`       | yes          | The field to transform. Must be a scalar field (see below). |
-| `pattern`     | yes          | The regex to replace, applied with `re.sub` (every match).  |
-| `replacement` | yes          | The replacement; backreferences such as `\1` are supported. |
-| `ignore-case` | no (`false`) | Match case-insensitively.                                   |
+| Setting       | Required     | Description                                                       |
+| ------------- | ------------ | ----------------------------------------------------------------- |
+| `field`       | yes          | The field to transform. Must be a scalar field (see below).       |
+| `pattern`     | yes          | The regex to replace, applied with `re.sub` (every match).        |
+| `replacement` | yes          | The replacement; backreferences such as `\1` are supported.       |
+| `ignore-case` | no (`false`) | Match case-insensitively.                                         |
+| `format`      | no (`false`) | Resolve `{project[...]}` references in `replacement` (see below). |
+
+With `format = true`, `replacement` is run through `str.format(project=...)`
+before substitution, so it can pull in fields produced by earlier entries — the
+same `{project[...]}` syntax as [`template`](#template). Backreferences keep
+working alongside it (braces and backslashes don't collide):
+
+```toml
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.plugins.substitute"
+field = "readme"
+pattern = "#(\\d+)"
+replacement = "[#\\1](https://github.com/org/repo/v{project[version]}/issues/\\1)"
+format = true
+```
+
+It is opt-in because formatting makes `{` and `}` special: with `format = true`
+a literal brace in the replacement must be doubled (`{{` / `}}`), as with any
+`str.format` string. Leave it off (the default) to use the replacement verbatim.
 
 `field` must be a single-value field — a string field (`version`, `description`,
 `requires-python`, `license`) or `readme` — and must already hold a value from

--- a/src/dynamic_metadata/plugins/substitute.py
+++ b/src/dynamic_metadata/plugins/substitute.py
@@ -16,7 +16,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-KEYS = {"field", "pattern", "replacement", "ignore-case"}
+KEYS = {"field", "pattern", "replacement", "ignore-case", "format"}
 
 
 def dynamic_metadata(
@@ -47,12 +47,22 @@ def dynamic_metadata(
         msg = "Setting 'ignore-case' must be a boolean"
         raise RuntimeError(msg)
 
+    do_format = settings.get("format", False)
+    if not isinstance(do_format, bool):
+        msg = "Setting 'format' must be a boolean"
+        raise RuntimeError(msg)
+
     if field not in project:
         msg = f"Field {field!r} must be produced by an earlier entry to substitute"
         raise RuntimeError(msg)
 
     pattern = settings["pattern"]
     replacement = settings["replacement"]
+    # Opt-in: resolve {project[...]} references against the snapshot, mirroring
+    # the template plugin. Off by default so literal braces in a replacement
+    # need no escaping.
+    if do_format:
+        replacement = replacement.format(project=project)
     flags = re.IGNORECASE if ignore_case else 0
 
     return {

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -843,6 +843,101 @@ def test_substitute_str_field() -> None:
     assert pyproject["description"] == "v 0.1.0"
 
 
+def test_substitute_format_references_field() -> None:
+    # With format=true, the replacement pulls in another field via {project[...]}.
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "version": "1.2.3", "dynamic": ["description"]},
+        [
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "description",
+                "result": "placeholder",
+            },
+            {
+                "provider": "dynamic_metadata.plugins.substitute",
+                "field": "description",
+                "pattern": "placeholder",
+                "replacement": "v{project[version]}",
+                "format": True,
+            },
+        ],
+        "wheel",
+    )
+
+    assert pyproject["description"] == "v1.2.3"
+
+
+def test_substitute_format_with_backreference() -> None:
+    # A regex backreference and a {project[...]} reference coexist in one
+    # replacement: braces and backslashes use disjoint syntax.
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "version": "1.2.3", "dynamic": ["description"]},
+        [
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "description",
+                "result": "#42",
+            },
+            {
+                "provider": "dynamic_metadata.plugins.substitute",
+                "field": "description",
+                "pattern": r"#(\d+)",
+                "replacement": r"{project[version]}-\1",
+                "format": True,
+            },
+        ],
+        "wheel",
+    )
+
+    assert pyproject["description"] == "1.2.3-42"
+
+
+def test_substitute_no_format_keeps_braces_literal() -> None:
+    # Default (format off): literal braces in the replacement pass through and
+    # are not treated as a format string. This is why format is opt-in.
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["description"]},
+        [
+            {
+                "provider": "dynamic_metadata.plugins.template",
+                "field": "description",
+                "result": "placeholder",
+            },
+            {
+                "provider": "dynamic_metadata.plugins.substitute",
+                "field": "description",
+                "pattern": "placeholder",
+                "replacement": "x{y}z",
+            },
+        ],
+        "wheel",
+    )
+
+    assert pyproject["description"] == "x{y}z"
+
+
+def test_substitute_format_rejects_non_bool() -> None:
+    with pytest.raises(RuntimeError, match="'format' must be a boolean"):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": ["description"]},
+            [
+                {
+                    "provider": "dynamic_metadata.plugins.template",
+                    "field": "description",
+                    "result": "placeholder",
+                },
+                {
+                    "provider": "dynamic_metadata.plugins.substitute",
+                    "field": "description",
+                    "pattern": "placeholder",
+                    "replacement": "x",
+                    "format": "yes",
+                },
+            ],
+            "wheel",
+        )
+
+
 def test_substitute_ignore_case() -> None:
     pyproject = dynamic_metadata.loader.process_dynamic_metadata(
         {"name": "test", "dynamic": ["readme"]},


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

Lets the `substitute` plugin's `replacement` reference other metadata fields via `{project[...]}` — the same `str.format(project=...)` mechanism the `template` plugin already uses for its `result`. This is the cross-field access asked about: previously `substitute` could only read and rewrite its own target field's value.

```toml
[[tool.dynamic-metadata]]
provider = "dynamic_metadata.plugins.substitute"
field = "description"
pattern = "placeholder"
replacement = "v{project[version]}"
format = true
```

## Why opt-in

A new `format` boolean (default `false`) gates the behavior. Applying `str.format` unconditionally would silently break any existing `replacement` containing literal `{`/`}` (those would now need `{{`/`}}` escaping). With `format` off, the replacement is used verbatim — current behavior is unchanged.

Regex backreferences (`\1`) keep working alongside `{project[...]}` since braces and backslashes use disjoint syntax.

## Changes

- `substitute.py`: add `format` to `KEYS`, validate it as a bool (mirroring `ignore-case`), and conditionally run `replacement` through `.format(project=project)`.
- `tests/test_package.py`: field reference, backreference + project-reference coexisting, literal braces passing through when `format` is off (backward-compat guard), and non-bool rejection.
- `docs/plugins.md`: document the `format` setting with an example and the `{{`/`}}` escaping caveat.

No schema change needed — the bundled JSON schema is generic and doesn't enumerate per-plugin settings.

## Verification

- `uv run pytest` → 63 passed
- `prek -a --quiet` → clean (ruff, prettier, mypy `--strict`)