### PR TITLE
feat: entry-point provider discovery with inline-table local form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ is still WiP and may change.
 The library is split into three audiences (see README.md):
 
 - **Users** configure plugins as an ordered array of tables,
-  `[[tool.dynamic-metadata]]`, each with a `provider` (a module, or a
-  `module:Class`) and optional `provider-path` (local dir). Entries run in
-  order.
+  `[[tool.dynamic-metadata]]`, each with a `provider`: either a registered
+  entry-point name (string) or an inline table `{path, module}` for a local
+  plugin. Entries run in order.
 - **Plugin authors** implement the hooks; they do _not_ need to depend on this
   package at runtime.
 - **Backend authors** consume `loader.py` to drive plugins; they also do not
@@ -45,14 +45,22 @@ warnings as errors and uses `--strict-markers --strict-config`.
 
 ### The plugin protocol
 
-A provider is either a module or a class (`provider = "module:Class"`); a class
-is instantiated with no args by `load_provider` and its hooks are bound methods
-(so they can share state via `self`). The one required hook is
-`dynamic_metadata(settings, project) -> dict[str, Any]`. It returns a fragment
-of the `[project]` table (`{field: value, ...}`), so one plugin may set several
-fields. Three optional hooks: `build_state(build_state) -> None` (called once
-before `dynamic_metadata` with the current build state — a provider that cares
-stashes it, typically on `self`; the loader detects it via
+A `provider` entry is one of two shapes, parsed by `_provider_location` and
+loaded by `load_provider(module, provider_path=None)`. A **string** is a name in
+the `dynamic_metadata.provider` entry-point group (bundled plugins register
+there — see `pyproject.toml`, names prefixed `dynamic_metadata.`; third-party
+plugins should prefix with their own package). An **inline table**
+`{path, module}` is a local import (loose in-project scripts) — there is no
+bare-import fallback. A duplicate name across distributions is a hard error. The
+loaded object is used per kind: module as-is, class instantiated with no args
+(hooks are bound methods sharing state via `self`), instance used directly.
+`list_providers()` enumerates names (also `dynamic-metadata providers`). The one
+required hook is `dynamic_metadata(settings, project) -> dict[str, Any]`. It
+returns a fragment of the `[project]` table (`{field: value, ...}`), so one
+plugin may set several fields. Three optional hooks:
+`build_state(build_state) -> None` (called once before `dynamic_metadata` with
+the current build state — a provider that cares stashes it, typically on `self`;
+the loader detects it via
 `isinstance(provider, DynamicMetadataBuildStateProtocol)`),
 `dynamic_wheel(settings) -> dict[str, bool]` (per-field METADATA 2.2 dynamic
 status; version must be false) and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,13 +54,14 @@ plugins should prefix with their own package). An **inline table**
 bare-import fallback. A duplicate name across distributions is a hard error. The
 loaded object is used per kind: module as-is, class instantiated with no args
 (hooks are bound methods sharing state via `self`), instance used directly.
-`list_providers()` enumerates names (also `dynamic-metadata providers`). The one
-required hook is `dynamic_metadata(settings, project) -> dict[str, Any]`. It
-returns a fragment of the `[project]` table (`{field: value, ...}`), so one
-plugin may set several fields. Three optional hooks:
-`build_state(build_state) -> None` (called once before `dynamic_metadata` with
-the current build state — a provider that cares stashes it, typically on `self`;
-the loader detects it via
+`list_providers()` enumerates names (also `dynamic-metadata providers`); it
+lives in `discovery.py`, kept out of the loader so `loader.py` stays the minimum
+a backend copies. The one required hook is
+`dynamic_metadata(settings, project) -> dict[str, Any]`. It returns a fragment
+of the `[project]` table (`{field: value, ...}`), so one plugin may set several
+fields. Three optional hooks: `build_state(build_state) -> None` (called once
+before `dynamic_metadata` with the current build state — a provider that cares
+stashes it, typically on `self`; the loader detects it via
 `isinstance(provider, DynamicMetadataBuildStateProtocol)`),
 `dynamic_wheel(settings) -> dict[str, bool]` (per-field METADATA 2.2 dynamic
 status; version must be false) and

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ build-backend = "..."
 dynamic = ["description", "version"]
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.regex"
+provider = "dynamic_metadata.regex"
 field = "version"
 input = "src/my_package/__init__.py"
 ```
@@ -43,7 +43,7 @@ produced above:
 
 ```toml
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.template"
+provider = "dynamic_metadata.template"
 field = "description"
 result = "This is {project[name]}, version {project[version]}"
 ```

--- a/docs/backend_authors.md
+++ b/docs/backend_authors.md
@@ -39,9 +39,8 @@ current directory.
 ## Reading the configuration
 
 Parse `pyproject.toml` and take `tool.dynamic-metadata` as an **ordered list of
-tables**. Each table has a required `provider` and an optional `provider-path`;
-every other key is plugin-specific and passed through verbatim as that plugin's
-`settings`.
+tables**. Each table has a required `provider`; every other key is
+plugin-specific and passed through verbatim as that plugin's `settings`.
 
 ```python
 import tomllib  # or tomli on <3.11
@@ -58,24 +57,44 @@ enforces this for you.
 
 ## Loading a provider
 
-A `provider` is either a module (`"pkg.mod"`) or a `module:Class`
-(`"pkg.mod:Class"`). A bare module is used as-is, so its hooks are module-level
-functions; a class is instantiated with no arguments, so its hooks are bound
-methods and can share state through `self`.
+A `provider` takes one of two shapes. A **string** is a name registered in the
+`dynamic_metadata.provider` entry-point group. An **inline table**
+`{ path, module }` names a local plugin: `module` (`"pkg.mod"` or
+`"pkg.mod:Class"`) is imported from the `path` directory. The module-path form
+is _only_ available via the table — an installed plugin is reachable through its
+entry point, not a bare import string.
+
+The loaded object is used according to its kind: a module is used as-is (hooks
+are module-level functions); a class is instantiated with no arguments (hooks
+are bound methods and can share state through `self`); an already-instantiated
+object (a `module:instance` entry point) is used directly.
 
 ```python
-import importlib
+from dynamic_metadata._compat.metadata import entry_points
 
 
-def load_provider(provider, provider_path=None):
-    module_name, _, class_name = provider.partition(":")
-    # provider_path handling omitted; see below
-    module = importlib.import_module(module_name)
-    return getattr(module, class_name)() if class_name else module
+def load_provider(spec):
+    if not isinstance(spec, str):  # inline table {path, module}
+        return import_from_path(spec["module"], spec["path"])  # see below
+    matches = [
+        ep for ep in entry_points("dynamic_metadata.provider") if ep.name == spec
+    ]
+    if not matches:
+        raise ModuleNotFoundError(f"Unknown provider {spec!r}")
+    obj = matches[0].load()  # >1 match is a collision → hard error
+    return obj() if isinstance(obj, type) else obj
 ```
 
-`provider-path` lets a plugin live inside the project being built (a local
-directory not installed as a package). The reference loader installs a
+Names are conventionally prefixed with the providing package (the bundled
+plugins are `dynamic_metadata.regex`, …); a name registered by more than one
+distribution is a hard error rather than a non-deterministic pick. This
+resolution is entirely internal to the loader; the backend-facing signatures of
+`process_dynamic_metadata` and `load_dynamic_metadata` are unchanged.
+`list_providers()` returns the registered names (useful for diagnostics), and
+the `dynamic-metadata providers` CLI prints them.
+
+The inline-table `path` lets a plugin live inside the project being built (a
+local directory not installed as a package). The reference loader installs a
 `sys.meta_path` finder scoped to that directory for the single import —
 mirroring how `pyproject_hooks` handles PEP 517's `backend-path` — so the
 in-tree provider wins over any same-named installed module and a missing
@@ -118,8 +137,7 @@ def collect_requires(entries):
 ```
 
 `load_dynamic_metadata` is a thin generator that loads each entry's provider and
-hands back the leftover keys as `settings` (it strips `provider` /
-`provider-path`).
+hands back the leftover keys as `settings` (it consumes only `provider`).
 
 ## Resolving the metadata
 

--- a/docs/backend_authors.md
+++ b/docs/backend_authors.md
@@ -90,8 +90,9 @@ plugins are `dynamic_metadata.regex`, …); a name registered by more than one
 distribution is a hard error rather than a non-deterministic pick. This
 resolution is entirely internal to the loader; the backend-facing signatures of
 `process_dynamic_metadata` and `load_dynamic_metadata` are unchanged.
-`list_providers()` returns the registered names (useful for diagnostics), and
-the `dynamic-metadata providers` CLI prints them.
+`list_providers()` returns the registered names (useful for diagnostics); it
+lives in `discovery.py` rather than `loader.py`, since a backend does not need
+it to resolve metadata. The `dynamic-metadata providers` CLI prints them.
 
 The inline-table `path` lets a plugin live inside the project being built (a
 local directory not installed as a package). The reference loader installs a

--- a/docs/plugin_authors.md
+++ b/docs/plugin_authors.md
@@ -11,6 +11,26 @@ module exposing these hooks as functions, or a class (`"<module>:<Class>"`)
 exposing them as methods — a class is instantiated with no arguments, so its
 hooks share state through `self`.
 
+## Registering a name
+
+An installed plugin is referenced by a name it registers in the
+`dynamic_metadata.provider` entry-point group — the module-path form is only for
+a loose script inside the project being built, given as an
+[inline table](users.md#providing-a-custom-plugin). So a distributed plugin
+registers:
+
+```toml
+[project.entry-points."dynamic_metadata.provider"]
+"my_package.my_plugin" = "my_package.plugin"   # or "my_package.plugin:MyClass"
+```
+
+The value points at the module or class exposing the hooks. **Prefix the name
+with your package name** (here `my_package.`) — the group is shared across every
+installed plugin, and a name registered by two distributions is a hard error.
+The bundled plugins follow this convention (`dynamic_metadata.regex`, …). This
+is the only reason to touch your `pyproject.toml`; the hooks are unchanged, and
+you still do not depend on `dynamic-metadata` at runtime.
+
 ## The required hook
 
 ```python

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -6,6 +6,10 @@ straight from its settings, and `readme_fragment` is single-purpose and always
 writes `readme`. Because they live inside `dynamic-metadata`, you must add
 `dynamic-metadata` to your `[build-system].requires` to use them.
 
+Each registers a provider name of `dynamic_metadata.` plus the heading below, so
+the `regex` plugin is `provider = "dynamic_metadata.regex"`. The examples use
+these names.
+
 Entries run in order and each sees the project resolved so far, so several
 entries can cooperate on one field: `readme_fragment` and `substitute` build a
 readme the way [hatch-fancy-pypi-readme][] assembles one — one entry per
@@ -24,7 +28,7 @@ assignment.
 dynamic = ["version"]
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.regex"
+provider = "dynamic_metadata.regex"
 field = "version"
 input = "src/my_package/__init__.py"
 ```
@@ -50,7 +54,7 @@ resolved by earlier entries, demonstrating cross-field references.
 
 ```toml
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.template"
+provider = "dynamic_metadata.template"
 field = "readme"
 result = "{project[name]} {project[version]}"
 ```
@@ -76,7 +80,7 @@ mapped to its value, returned verbatim.
 dynamic = ["version", "description"]
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.static"
+provider = "dynamic_metadata.static"
 version = "1.2.3"
 description = "My package"
 ```
@@ -95,11 +99,11 @@ like `substitute` a _dynamic_ value to transform, which a field set in
 dynamic = ["version"]
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.static"
+provider = "dynamic_metadata.static"
 version = "1.2.3-beta"
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.substitute"
+provider = "dynamic_metadata.substitute"
 field = "version"
 pattern = "-beta$"
 replacement = "b0"
@@ -121,18 +125,18 @@ fragment; an entry with `path` reads a file and may slice it.
 dynamic = ["readme"]
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.readme_fragment"
+provider = "dynamic_metadata.readme_fragment"
 content-type = "text/markdown"
 text = "# My Project\n\n"
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.readme_fragment"
+provider = "dynamic_metadata.readme_fragment"
 path = "README.md"
 start-after = "<!-- start -->\n"
 end-before = "\n<!-- end -->"
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.readme_fragment"
+provider = "dynamic_metadata.readme_fragment"
 path = "CHANGELOG.md"
 pattern = "(## .*?)(?=\n## )"
 ```
@@ -161,7 +165,7 @@ an assembled readme (for example, turning `#123` into a link).
 
 ```toml
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.substitute"
+provider = "dynamic_metadata.substitute"
 field = "readme"
 pattern = "#(\\d+)"
 replacement = "[#\\1](https://github.com/org/repo/issues/\\1)"
@@ -184,7 +188,7 @@ working alongside it (braces and backslashes don't collide):
 
 ```toml
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.substitute"
+provider = "dynamic_metadata.substitute"
 field = "readme"
 pattern = "#(\\d+)"
 replacement = "[#\\1](https://github.com/org/repo/v{project[version]}/issues/\\1)"

--- a/docs/users.md
+++ b/docs/users.md
@@ -2,25 +2,29 @@
 
 Plugins are configured as an **ordered array of tables**,
 `[[tool.dynamic-metadata]]`. Each entry must specify a `provider` exposing the
-plugin API; everything else in the entry is passed to that plugin as settings. A
-`provider` is either a module (`"<module>"`) or a class within a module
-(`"<module>:<Class>"`); a class is instantiated and its hooks are called as
-methods.
+plugin API; everything else in the entry is passed to that plugin as settings.
+
+An installed plugin is referenced by the **name** it registers in the
+`dynamic_metadata.provider` entry-point group. Names are conventionally prefixed
+with the providing package, so the bundled plugins are `dynamic_metadata.regex`,
+`dynamic_metadata.template`, and so on:
 
 ```toml
 [[tool.dynamic-metadata]]
-provider = "<module>"        # or "<module>:<Class>"
+provider = "dynamic_metadata.regex"
 # ... plugin settings ...
 ```
+
+Run `dynamic-metadata providers` to see the names available in your environment.
+A plugin that lives inside your own project rather than an installed
+distribution is instead given as an [inline table](#providing-a-custom-plugin)
+with `path` and `module` keys.
 
 Entries run **in order**, so a later entry sees every field an earlier entry
 produced. This makes resolution order explicit (no dependency graph), lets you
 modify one field with several plugins, and means a plugin can read another
-field's value simply with `project[...]`.
-
-There is an optional key, `provider-path`, which specifies a local directory to
-load the plugin from, allowing plugins to live inside your own project. Plugins
-can, if desired, use their own `tool.*` sections as well.
+field's value simply with `project[...]`. Plugins can, if desired, use their own
+`tool.*` sections as well.
 
 Your build backend _must support_ dynamic-metadata for this to work. Build
 backends known to support this currently include:
@@ -40,23 +44,25 @@ build-backend = "..."
 dynamic = ["version"]
 
 [[tool.dynamic-metadata]]
-provider = "dynamic_metadata.plugins.regex"
+provider = "dynamic_metadata.regex"
 field = "version"
 input = "src/my_package/__init__.py"
 ```
 
-Since this plugin lives inside `dynamic-metadata`, you have to include that in
-your requirements. Make sure the field is marked dynamic in your project table.
-The settings are defined by the plugin; see [Bundled plugins](plugins.md) for
-the full list of settings each one accepts.
+`dynamic_metadata.regex` is the registered name of the bundled plugin. Since it
+lives inside `dynamic-metadata`, you have to include that in your requirements.
+Make sure the field is marked dynamic in your project table. The settings are
+defined by the plugin; see [Bundled plugins](plugins.md) for the full list of
+settings each one accepts.
 
 ## Providing a custom plugin
 
 You don't have to publish a plugin, or even put it in an installed package, to
-use one. The optional `provider-path` key names a local directory to import the
-`provider` module from, so a plugin can live right inside your project alongside
-`pyproject.toml`. A provider loaded this way needs no runtime dependency on
-`dynamic-metadata` — it just has to expose the [hooks](plugin_authors.md).
+use one. Give `provider` as an **inline table** with a `path` (a local
+directory) and a `module` (imported from it), so a plugin can live right inside
+your project alongside `pyproject.toml`. A provider loaded this way needs no
+runtime dependency on `dynamic-metadata` — it just has to expose the
+[hooks](plugin_authors.md).
 
 Drop a module in your project — say `scripts/my_plugin.py`:
 
@@ -65,24 +71,22 @@ def dynamic_metadata(settings, project):
     return {"version": "1.2.3"}
 ```
 
-and point an entry at it with `provider-path`:
+and point an entry at it:
 
 ```toml
 [project]
 dynamic = ["version"]
 
 [[tool.dynamic-metadata]]
-provider = "my_plugin"
-provider-path = "scripts"
+provider = { path = "scripts", module = "my_plugin" }
 ```
 
-`provider` is still the module name (`my_plugin`, the file without its `.py`),
-and `provider-path` is the directory to find it in (relative to
-`pyproject.toml`). It must be an existing directory, and it is searched in
-isolation: a module of the same name reachable elsewhere on `sys.path` will not
-shadow or substitute for one missing from `provider-path`. A
-`"<module>:<Class>"` provider works the same way — the class is imported from
-`provider-path` and instantiated.
+`module` is the module name (`my_plugin`, the file without its `.py`), and
+`path` is the directory to find it in (relative to `pyproject.toml`). It must be
+an existing directory, and it is searched in isolation: a module of the same
+name reachable elsewhere on `sys.path` will not shadow or substitute for one
+missing from `path`. Use `module = "my_plugin:MyClass"` to load a class — it is
+imported and instantiated the same way.
 
 Because the module is imported, make sure any third-party packages it needs are
 available at build time. If they aren't already pulled in by your build backend,
@@ -105,6 +109,10 @@ $ dynamic-metadata show
 `[project]` table as JSON. Use `--pyproject-toml PATH` to point at another file
 and `--state` to choose the build state passed to plugins (default
 `metadata_wheel`).
+
+`dynamic-metadata providers` lists the provider names registered in your
+environment (the bundled plugins plus any installed third-party plugins) and the
+module each resolves to.
 
 ## Mixing static and dynamic values (PEP 808)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ Changelog = "https://github.com/scikit-build/dynamic-metadata/releases"
 [project.entry-points."validate_pyproject.tool_schema"]
 dynamic-metadata = "dynamic_metadata.schema:get_schema"
 
+[project.entry-points."dynamic_metadata.provider"]
+"dynamic_metadata.regex" = "dynamic_metadata.plugins.regex"
+"dynamic_metadata.template" = "dynamic_metadata.plugins.template"
+"dynamic_metadata.substitute" = "dynamic_metadata.plugins.substitute"
+"dynamic_metadata.static" = "dynamic_metadata.plugins.static"
+"dynamic_metadata.readme_fragment" = "dynamic_metadata.plugins.readme_fragment"
+
 [tool.flit.sdist]
 include = ["tests/**/*.py", "docs/"]
 exclude = ["**/*.egg-info", "docs/_build"]

--- a/src/dynamic_metadata/__main__.py
+++ b/src/dynamic_metadata/__main__.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from ._compat import tomllib
-from .loader import BUILD_STATES, list_providers, process_dynamic_metadata
+from .discovery import list_providers
+from .loader import BUILD_STATES, process_dynamic_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/dynamic_metadata/__main__.py
+++ b/src/dynamic_metadata/__main__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from ._compat import tomllib
-from .loader import BUILD_STATES, process_dynamic_metadata
+from .loader import BUILD_STATES, list_providers, process_dynamic_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -34,9 +34,28 @@ def main_show(args: argparse.Namespace, /) -> None:
     print(json.dumps(project, indent=2))
 
 
+def main_providers(_args: argparse.Namespace, /) -> None:
+    """Print the registered provider names and where each resolves to."""
+    providers = list_providers()
+    if not providers:
+        print("No providers registered.")
+        return
+    width = max(len(name) for name in providers)
+    for name in sorted(providers):
+        print(f"{name:<{width}}  {providers[name]}")
+
+
 def populate_parser(parser: argparse.ArgumentParser, /) -> None:
     """Add the ``dynamic-metadata`` subcommands to an existing parser."""
     subparsers = parser.add_subparsers(required=True, help="Commands")
+    providers = subparsers.add_parser(
+        "providers",
+        help="List the registered dynamic-metadata providers",
+        description="Lists every provider registered in the "
+        "'dynamic_metadata.provider' entry-point group (the bundled plugins "
+        "plus any installed third-party plugins) and where each resolves to.",
+    )
+    providers.set_defaults(func=main_providers)
     show = subparsers.add_parser(
         "show",
         help="Show the project table with dynamic metadata resolved",

--- a/src/dynamic_metadata/_compat/metadata.py
+++ b/src/dynamic_metadata/_compat/metadata.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import importlib.metadata
+import sys
+
+__all__ = ["entry_points"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+# The selectable ``group=`` keyword arrived in 3.10; before that ``entry_points()``
+# takes no argument and returns a ``dict`` of groups. On 3.10+ the no-argument form
+# warns, which this project's ``filterwarnings = error`` would turn into a test
+# failure, so the two paths are split at import time.
+if sys.version_info >= (3, 10):
+
+    def entry_points(group: str) -> list[importlib.metadata.EntryPoint]:
+        """Return the entry points in ``group`` across installed distributions."""
+        return list(importlib.metadata.entry_points(group=group))
+
+else:
+
+    def entry_points(group: str) -> list[importlib.metadata.EntryPoint]:
+        """Return the entry points in ``group`` across installed distributions."""
+        return list(importlib.metadata.entry_points().get(group, []))

--- a/src/dynamic_metadata/_compat/metadata.py
+++ b/src/dynamic_metadata/_compat/metadata.py
@@ -24,4 +24,6 @@ else:
 
     def entry_points(group: str) -> list[importlib.metadata.EntryPoint]:
         """Return the entry points in ``group`` across installed distributions."""
-        return list(importlib.metadata.entry_points().get(group, []))
+        # Pre-3.10 entry_points() returns a dict; pylint checks the 3.10+ stub.
+        eps = importlib.metadata.entry_points()
+        return list(eps.get(group, []))  # pylint: disable=no-member

--- a/src/dynamic_metadata/discovery.py
+++ b/src/dynamic_metadata/discovery.py
@@ -1,0 +1,31 @@
+"""Provider discovery helpers.
+
+Not part of the minimum a backend needs to resolve dynamic metadata (that is
+``loader.py``); this is tooling for listing what is installed, used by the
+``dynamic-metadata providers`` command.
+"""
+
+from __future__ import annotations
+
+from ._compat import metadata
+from .loader import PROVIDER_GROUP, _entry_point_dist
+
+__all__ = ["list_providers"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def list_providers() -> dict[str, str]:
+    """Map each registered provider name to a human-readable descriptor.
+
+    Discovers every entry point in ``PROVIDER_GROUP`` (the bundled plugins plus
+    any installed third-party plugins). The descriptor is the entry-point value,
+    annotated with the providing distribution when available.
+    """
+    providers: dict[str, str] = {}
+    for ep in metadata.entry_points(PROVIDER_GROUP):
+        dist = _entry_point_dist(ep)
+        providers[ep.name] = f"{ep.value} ({dist})" if dist else ep.value
+    return providers

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
 
 __all__ = [
     "BuildState",
-    "list_providers",
     "load_dynamic_metadata",
     "load_provider",
     "process_dynamic_metadata",
@@ -258,27 +257,13 @@ def load_provider(
 
     loaded = _load_entry_point(provider)
     if loaded is None:
-        known = sorted(list_providers())
+        known = sorted({ep.name for ep in metadata.entry_points(PROVIDER_GROUP)})
         matches = difflib.get_close_matches(provider, known)
         hint = f"; did you mean {matches[0]!r}?" if matches else ""
         available = ", ".join(known) or "none"
         msg = f"Unknown provider {provider!r}{hint} (available: {available})"
         raise ModuleNotFoundError(msg)
     return _instantiate(loaded)
-
-
-def list_providers() -> dict[str, str]:
-    """Map each registered provider name to a human-readable descriptor.
-
-    Discovers every entry point in ``PROVIDER_GROUP`` (the bundled plugins plus
-    any installed third-party plugins). The descriptor is the entry-point value,
-    annotated with the providing distribution when available.
-    """
-    providers: dict[str, str] = {}
-    for ep in metadata.entry_points(PROVIDER_GROUP):
-        dist = _entry_point_dist(ep)
-        providers[ep.name] = f"{ep.value} ({dist})" if dist else ep.value
-    return providers
 
 
 def _provider_location(spec: Any) -> tuple[str, str | None]:

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     Literal,
     Protocol,
-    Union,
     cast,
     get_args,
     runtime_checkable,
@@ -80,17 +79,6 @@ class DynamicMetadataRequirementsProtocol(DynamicMetadataProtocol, Protocol):
 class DynamicMetadataWheelProtocol(DynamicMetadataProtocol, Protocol):
     def dynamic_wheel(self, settings: Mapping[str, Any]) -> dict[str, bool]: ...
 
-
-DMProtocols = Union[
-    DynamicMetadataProtocol,
-    DynamicMetadataBuildStateProtocol,
-    DynamicMetadataRequirementsProtocol,
-    DynamicMetadataWheelProtocol,
-]
-
-# The only per-entry key consumed by the loader itself; everything else is
-# plugin settings, passed through verbatim to the provider.
-RESERVED_KEYS = frozenset(["provider"])
 
 # Entry-point group a plugin distribution registers a named provider under. The
 # bundled plugins register here too (see pyproject.toml).
@@ -179,7 +167,7 @@ def _merge_metadata(field: str, static: Any, dynamic: Any) -> Any:
     return merged_groups
 
 
-def _instantiate(obj: Any) -> DMProtocols:
+def _instantiate(obj: Any) -> DynamicMetadataProtocol:
     """Turn a loaded object into the provider whose hooks are called.
 
     A class is instantiated with no arguments so its hooks are bound methods and
@@ -187,7 +175,7 @@ def _instantiate(obj: Any) -> DMProtocols:
     stashing the build state for ``dynamic_metadata`` to read). A module or an
     already-instantiated object is used as-is.
     """
-    return cast("DMProtocols", obj() if inspect.isclass(obj) else obj)
+    return cast("DynamicMetadataProtocol", obj() if inspect.isclass(obj) else obj)
 
 
 def _import_provider(provider: str, provider_path: str | None = None) -> Any:
@@ -222,10 +210,10 @@ def _entry_point_dist(ep: EntryPoint) -> str | None:
 def _load_entry_point(name: str) -> Any:
     """Load a provider registered under ``name`` in ``PROVIDER_GROUP``.
 
-    Returns the loaded object, or ``None`` if no entry point matches (so the
-    caller can fall back to importing ``name`` as a module). Raises if more than
-    one distribution registers the name (a non-deterministic collision) or the
-    entry point cannot be loaded.
+    Returns the loaded object, or ``None`` if no entry point matches (the caller
+    turns this into an "unknown provider" error). Raises if more than one
+    distribution registers the name (a non-deterministic collision) or the entry
+    point cannot be loaded.
     """
     eps = [ep for ep in metadata.entry_points(PROVIDER_GROUP) if ep.name == name]
     if not eps:
@@ -248,7 +236,7 @@ def _load_entry_point(name: str) -> Any:
 def load_provider(
     provider: str,
     provider_path: str | None = None,
-) -> DMProtocols:
+) -> DynamicMetadataProtocol:
     """Load a provider, returning the object whose hooks are called.
 
     ``provider`` is resolved in one of two ways:
@@ -313,7 +301,7 @@ def _provider_location(spec: Any) -> tuple[str, str | None]:
 
 def load_dynamic_metadata(
     entries: Sequence[Mapping[str, Any]],
-) -> Generator[tuple[DMProtocols, dict[str, Any]], None, None]:
+) -> Generator[tuple[DynamicMetadataProtocol, dict[str, Any]], None, None]:
     """Load each entry's provider, yielding it with its plugin settings.
 
     Entries are processed in order; ``provider`` is consumed here and the
@@ -323,7 +311,9 @@ def load_dynamic_metadata(
         if "provider" not in entry:
             msg = "Each [[tool.dynamic-metadata]] entry must set a 'provider'"
             raise KeyError(msg)
-        settings = {k: v for k, v in entry.items() if k not in RESERVED_KEYS}
+        # 'provider' is the only key the loader consumes; the rest are plugin
+        # settings, passed through verbatim to the provider.
+        settings = {k: v for k, v in entry.items() if k != "provider"}
         provider = load_provider(*_provider_location(entry["provider"]))
         yield provider, settings
 

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import difflib
 import importlib
 import importlib.abc
 import importlib.machinery
+import inspect
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 from typing import (
@@ -12,10 +15,12 @@ from typing import (
     Literal,
     Protocol,
     Union,
+    cast,
     get_args,
     runtime_checkable,
 )
 
+from ._compat import metadata
 from .info import (
     ALL_FIELDS,
     DICT_STR_FIELDS,
@@ -31,13 +36,15 @@ BuildState = Literal[
 BUILD_STATES: frozenset[str] = frozenset(get_args(BuildState))
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping, Sequence
+    from collections.abc import Generator, Sequence
     from importlib.machinery import ModuleSpec
+    from importlib.metadata import EntryPoint
     from types import ModuleType
 
 
 __all__ = [
     "BuildState",
+    "list_providers",
     "load_dynamic_metadata",
     "load_provider",
     "process_dynamic_metadata",
@@ -81,9 +88,13 @@ DMProtocols = Union[
     DynamicMetadataWheelProtocol,
 ]
 
-# Per-entry keys consumed by the loader itself; everything else is plugin
-# settings, passed through verbatim to the provider.
-RESERVED_KEYS = frozenset(["provider", "provider-path"])
+# The only per-entry key consumed by the loader itself; everything else is
+# plugin settings, passed through verbatim to the provider.
+RESERVED_KEYS = frozenset(["provider"])
+
+# Entry-point group a plugin distribution registers a named provider under. The
+# bundled plugins register here too (see pyproject.toml).
+PROVIDER_GROUP = "dynamic_metadata.provider"
 
 
 class _ProviderPathFinder(importlib.abc.MetaPathFinder):
@@ -168,18 +179,21 @@ def _merge_metadata(field: str, static: Any, dynamic: Any) -> Any:
     return merged_groups
 
 
-def load_provider(
-    provider: str,
-    provider_path: str | None = None,
-) -> DMProtocols:
-    """Load a provider, returning the object whose hooks are called.
+def _instantiate(obj: Any) -> DMProtocols:
+    """Turn a loaded object into the provider whose hooks are called.
 
-    ``provider`` is either a module path (``"pkg.mod"``) or a module path and a
-    class within it (``"pkg.mod:Class"``). A bare module is returned as-is, so
-    its hooks are plain module-level functions; a class is instantiated with no
-    arguments and the instance is returned, so its hooks are bound methods and
+    A class is instantiated with no arguments so its hooks are bound methods and
     may share state through ``self`` (e.g. the optional ``build_state`` hook
-    stashing the build state for ``dynamic_metadata`` to read).
+    stashing the build state for ``dynamic_metadata`` to read). A module or an
+    already-instantiated object is used as-is.
+    """
+    return cast("DMProtocols", obj() if inspect.isclass(obj) else obj)
+
+
+def _import_provider(provider: str, provider_path: str | None = None) -> Any:
+    """Import ``provider`` (``"pkg.mod"`` or ``"pkg.mod:Class"``) as an object.
+
+    Returns the module, or the named attribute within it, without instantiating.
     """
     module_name, _, class_name = provider.partition(":")
 
@@ -196,7 +210,105 @@ def load_provider(
         finally:
             sys.meta_path.remove(finder)
 
-    return getattr(module, class_name)() if class_name else module
+    return getattr(module, class_name) if class_name else module
+
+
+def _entry_point_dist(ep: EntryPoint) -> str | None:
+    """Best-effort distribution name for an entry point (for messages)."""
+    dist = getattr(ep, "dist", None)
+    return getattr(dist, "name", None) if dist is not None else None
+
+
+def _load_entry_point(name: str) -> Any:
+    """Load a provider registered under ``name`` in ``PROVIDER_GROUP``.
+
+    Returns the loaded object, or ``None`` if no entry point matches (so the
+    caller can fall back to importing ``name`` as a module). Raises if more than
+    one distribution registers the name (a non-deterministic collision) or the
+    entry point cannot be loaded.
+    """
+    eps = [ep for ep in metadata.entry_points(PROVIDER_GROUP) if ep.name == name]
+    if not eps:
+        return None
+    if len(eps) > 1:
+        dists = ", ".join(sorted(_entry_point_dist(ep) or ep.value for ep in eps))
+        msg = (
+            f"Provider name {name!r} is registered by multiple distributions "
+            f"({dists}); use an explicit 'module' or 'module:Class' provider"
+        )
+        raise ValueError(msg)
+    ep = eps[0]
+    try:
+        return ep.load()
+    except (ImportError, AttributeError) as exc:
+        msg = f"Could not load provider {name!r} ({ep.value!r}): {exc}"
+        raise ImportError(msg) from exc
+
+
+def load_provider(
+    provider: str,
+    provider_path: str | None = None,
+) -> DMProtocols:
+    """Load a provider, returning the object whose hooks are called.
+
+    ``provider`` is resolved in one of two ways:
+
+    * With ``provider_path`` (required for the module-path form), it is imported
+      from that directory as a module path (``"pkg.mod"`` or ``"pkg.mod:Class"``);
+      entry points are not consulted. This is for a plugin living inside the
+      project being built, not installed as a distribution.
+    * Otherwise it is a name registered in the ``PROVIDER_GROUP`` entry-point
+      group. An installed plugin is only reachable this way — a raw import path
+      without ``provider-path`` is not accepted.
+
+    A bare module is returned as-is (hooks are module-level functions); a class
+    is instantiated with no arguments; an already-instantiated object is used
+    directly.
+    """
+    if provider_path is not None:
+        return _instantiate(_import_provider(provider, provider_path))
+
+    loaded = _load_entry_point(provider)
+    if loaded is None:
+        known = sorted(list_providers())
+        matches = difflib.get_close_matches(provider, known)
+        hint = f"; did you mean {matches[0]!r}?" if matches else ""
+        available = ", ".join(known) or "none"
+        msg = f"Unknown provider {provider!r}{hint} (available: {available})"
+        raise ModuleNotFoundError(msg)
+    return _instantiate(loaded)
+
+
+def list_providers() -> dict[str, str]:
+    """Map each registered provider name to a human-readable descriptor.
+
+    Discovers every entry point in ``PROVIDER_GROUP`` (the bundled plugins plus
+    any installed third-party plugins). The descriptor is the entry-point value,
+    annotated with the providing distribution when available.
+    """
+    providers: dict[str, str] = {}
+    for ep in metadata.entry_points(PROVIDER_GROUP):
+        dist = _entry_point_dist(ep)
+        providers[ep.name] = f"{ep.value} ({dist})" if dist else ep.value
+    return providers
+
+
+def _provider_location(spec: Any) -> tuple[str, str | None]:
+    """Resolve a ``provider`` value into ``(module, provider_path)``.
+
+    A string is a registered entry-point name (no path). An inline table names a
+    local plugin to import from a directory, with exactly ``path`` (the
+    directory) and ``module`` (``"pkg.mod"`` or ``"pkg.mod:Class"``) keys.
+    """
+    if isinstance(spec, str):
+        return spec, None
+    if not isinstance(spec, Mapping) or set(spec) != {"path", "module"}:
+        msg = (
+            "'provider' must be a registered name (string) or an inline table "
+            "with exactly 'path' and 'module' keys"
+        )
+        raise ValueError(msg)
+    return spec["module"], spec["path"]
 
 
 def load_dynamic_metadata(
@@ -204,15 +316,15 @@ def load_dynamic_metadata(
 ) -> Generator[tuple[DMProtocols, dict[str, Any]], None, None]:
     """Load each entry's provider, yielding it with its plugin settings.
 
-    Entries are processed in order; ``provider`` and ``provider-path`` are
-    consumed here and the remaining keys are returned as plugin settings.
+    Entries are processed in order; ``provider`` is consumed here and the
+    remaining keys are returned as plugin settings.
     """
     for entry in entries:
         if "provider" not in entry:
             msg = "Each [[tool.dynamic-metadata]] entry must set a 'provider'"
             raise KeyError(msg)
         settings = {k: v for k, v in entry.items() if k not in RESERVED_KEYS}
-        provider = load_provider(entry["provider"], entry.get("provider-path"))
+        provider = load_provider(*_provider_location(entry["provider"]))
         yield provider, settings
 
 

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -166,35 +166,24 @@ def _merge_metadata(field: str, static: Any, dynamic: Any) -> Any:
     return merged_groups
 
 
-def _instantiate(obj: Any) -> DynamicMetadataProtocol:
-    """Turn a loaded object into the provider whose hooks are called.
-
-    A class is instantiated with no arguments so its hooks are bound methods and
-    may share state through ``self`` (e.g. the optional ``build_state`` hook
-    stashing the build state for ``dynamic_metadata`` to read). A module or an
-    already-instantiated object is used as-is.
-    """
-    return cast("DynamicMetadataProtocol", obj() if inspect.isclass(obj) else obj)
-
-
-def _import_provider(provider: str, provider_path: str) -> Any:
-    """Import ``provider`` (``"pkg.mod"`` or ``"pkg.mod:Class"``) from a directory.
+def _import_provider(module: str, path: str) -> Any:
+    """Import ``module`` (``"pkg.mod"`` or ``"pkg.mod:Class"``) from the ``path`` directory.
 
     Returns the module, or the named attribute within it, without instantiating.
     """
-    if not Path(provider_path).is_dir():
-        msg = "provider-path must be an existing directory"
+    if not Path(path).is_dir():
+        msg = f"provider 'path' {path!r} must be an existing directory"
         raise ValueError(msg)
 
-    module_name, _, class_name = provider.partition(":")
-    finder = _ProviderPathFinder([provider_path], module_name)
+    module_name, _, class_name = module.partition(":")
+    finder = _ProviderPathFinder([path], module_name)
     sys.meta_path.insert(0, finder)
     try:
-        module = importlib.import_module(module_name)
+        imported = importlib.import_module(module_name)
     finally:
         sys.meta_path.remove(finder)
 
-    return getattr(module, class_name) if class_name else module
+    return getattr(imported, class_name) if class_name else imported
 
 
 def _entry_point_dist(ep: EntryPoint) -> str | None:
@@ -204,16 +193,20 @@ def _entry_point_dist(ep: EntryPoint) -> str | None:
 
 
 def _load_entry_point(name: str) -> Any:
-    """Load a provider registered under ``name`` in ``PROVIDER_GROUP``.
+    """Load the provider registered under ``name`` in ``PROVIDER_GROUP``.
 
-    Returns the loaded object, or ``None`` if no entry point matches (the caller
-    turns this into an "unknown provider" error). Raises if more than one
-    distribution registers the name (a non-deterministic collision) or the entry
-    point cannot be loaded.
+    Raises if ``name`` is unknown (with a spelling hint), is registered by more
+    than one distribution (a non-deterministic collision), or fails to import.
     """
-    eps = [ep for ep in metadata.entry_points(PROVIDER_GROUP) if ep.name == name]
+    all_eps = list(metadata.entry_points(PROVIDER_GROUP))
+    eps = [ep for ep in all_eps if ep.name == name]
     if not eps:
-        return None
+        known = sorted({ep.name for ep in all_eps})
+        matches = difflib.get_close_matches(name, known)
+        hint = f"; did you mean {matches[0]!r}?" if matches else ""
+        available = ", ".join(known) or "none"
+        msg = f"Unknown provider {name!r}{hint} (available: {available})"
+        raise ModuleNotFoundError(msg)
     if len(eps) > 1:
         dists = ", ".join(sorted(_entry_point_dist(ep) or ep.value for ep in eps))
         msg = (
@@ -229,56 +222,35 @@ def _load_entry_point(name: str) -> Any:
         raise ImportError(msg) from exc
 
 
-def load_provider(
-    provider: str,
-    provider_path: str | None = None,
-) -> DynamicMetadataProtocol:
-    """Load a provider, returning the object whose hooks are called.
+def load_provider(provider: object) -> DynamicMetadataProtocol:
+    """Load a provider from its config value, returning the object whose hooks are called.
 
-    ``provider`` is resolved in one of two ways:
+    ``provider`` is the value of the ``provider`` key in a
+    ``[[tool.dynamic-metadata]]`` entry, in one of two forms:
 
-    * With ``provider_path`` (required for the module-path form), it is imported
-      from that directory as a module path (``"pkg.mod"`` or ``"pkg.mod:Class"``);
-      entry points are not consulted. This is for a plugin living inside the
-      project being built, not installed as a distribution.
-    * Otherwise it is a name registered in the ``PROVIDER_GROUP`` entry-point
-      group. An installed plugin is only reachable this way — a raw import path
-      without ``provider-path`` is not accepted.
+    * a **string** — a name registered in the ``PROVIDER_GROUP`` entry-point
+      group. Installed plugins are only reachable this way; a raw import path is
+      not accepted.
+    * an **inline table** ``{path, module}`` — a local plugin imported from the
+      ``path`` directory as a module path (``"pkg.mod"`` or ``"pkg.mod:Class"``),
+      for a plugin living inside the project being built. Entry points are not
+      consulted.
 
     A bare module is returned as-is (hooks are module-level functions); a class
-    is instantiated with no arguments; an already-instantiated object is used
-    directly.
+    is instantiated with no arguments so its hooks are bound methods sharing
+    state through ``self``; an already-instantiated object is used directly.
     """
-    if provider_path is not None:
-        return _instantiate(_import_provider(provider, provider_path))
-
-    loaded = _load_entry_point(provider)
-    if loaded is None:
-        known = sorted({ep.name for ep in metadata.entry_points(PROVIDER_GROUP)})
-        matches = difflib.get_close_matches(provider, known)
-        hint = f"; did you mean {matches[0]!r}?" if matches else ""
-        available = ", ".join(known) or "none"
-        msg = f"Unknown provider {provider!r}{hint} (available: {available})"
-        raise ModuleNotFoundError(msg)
-    return _instantiate(loaded)
-
-
-def _provider_location(spec: Any) -> tuple[str, str | None]:
-    """Resolve a ``provider`` value into ``(module, provider_path)``.
-
-    A string is a registered entry-point name (no path). An inline table names a
-    local plugin to import from a directory, with exactly ``path`` (the
-    directory) and ``module`` (``"pkg.mod"`` or ``"pkg.mod:Class"``) keys.
-    """
-    if isinstance(spec, str):
-        return spec, None
-    if not isinstance(spec, Mapping) or set(spec) != {"path", "module"}:
+    if isinstance(provider, str):
+        obj = _load_entry_point(provider)
+    elif isinstance(provider, Mapping) and set(provider) == {"path", "module"}:
+        obj = _import_provider(provider["module"], provider["path"])
+    else:
         msg = (
             "'provider' must be a registered name (string) or an inline table "
             "with exactly 'path' and 'module' keys"
         )
         raise ValueError(msg)
-    return spec["module"], spec["path"]
+    return cast("DynamicMetadataProtocol", obj() if inspect.isclass(obj) else obj)
 
 
 def load_dynamic_metadata(
@@ -296,8 +268,7 @@ def load_dynamic_metadata(
         # 'provider' is the only key the loader consumes; the rest are plugin
         # settings, passed through verbatim to the provider.
         settings = {k: v for k, v in entry.items() if k != "provider"}
-        provider = load_provider(*_provider_location(entry["provider"]))
-        yield provider, settings
+        yield load_provider(entry["provider"]), settings
 
 
 def process_dynamic_metadata(

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -177,25 +177,22 @@ def _instantiate(obj: Any) -> DynamicMetadataProtocol:
     return cast("DynamicMetadataProtocol", obj() if inspect.isclass(obj) else obj)
 
 
-def _import_provider(provider: str, provider_path: str | None = None) -> Any:
-    """Import ``provider`` (``"pkg.mod"`` or ``"pkg.mod:Class"``) as an object.
+def _import_provider(provider: str, provider_path: str) -> Any:
+    """Import ``provider`` (``"pkg.mod"`` or ``"pkg.mod:Class"``) from a directory.
 
     Returns the module, or the named attribute within it, without instantiating.
     """
-    module_name, _, class_name = provider.partition(":")
+    if not Path(provider_path).is_dir():
+        msg = "provider-path must be an existing directory"
+        raise ValueError(msg)
 
-    if provider_path is None:
+    module_name, _, class_name = provider.partition(":")
+    finder = _ProviderPathFinder([provider_path], module_name)
+    sys.meta_path.insert(0, finder)
+    try:
         module = importlib.import_module(module_name)
-    else:
-        if not Path(provider_path).is_dir():
-            msg = "provider-path must be an existing directory"
-            raise ValueError(msg)
-        finder = _ProviderPathFinder([provider_path], module_name)
-        sys.meta_path.insert(0, finder)
-        try:
-            module = importlib.import_module(module_name)
-        finally:
-            sys.meta_path.remove(finder)
+    finally:
+        sys.meta_path.remove(finder)
 
     return getattr(module, class_name) if class_name else module
 

--- a/src/dynamic_metadata/resources/toml_schema.json
+++ b/src/dynamic_metadata/resources/toml_schema.json
@@ -10,8 +10,24 @@
       "required": ["provider"],
       "additionalProperties": true,
       "properties": {
-        "provider": { "type": "string" },
-        "provider-path": { "type": "string" }
+        "provider": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "A registered provider entry-point name."
+            },
+            {
+              "type": "object",
+              "description": "A local plugin imported from a directory.",
+              "required": ["path", "module"],
+              "additionalProperties": false,
+              "properties": {
+                "path": { "type": "string" },
+                "module": { "type": "string" }
+              }
+            }
+          ]
+        }
       }
     }
   }

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,14 +1,30 @@
 from __future__ import annotations
 
 import json
+from importlib.metadata import EntryPoint
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import dynamic_metadata.__main__
 import dynamic_metadata.loader
 import dynamic_metadata.plugins
+from dynamic_metadata._compat import metadata as compat_metadata
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _fake_group(*eps: EntryPoint) -> Callable[[str], list[EntryPoint]]:
+    """Stand in for the entry-point shim, serving ``eps`` for the provider group."""
+    group = dynamic_metadata.loader.PROVIDER_GROUP
+    return lambda name: list(eps) if name == group else []
+
+
+def _write_provider(plugin_dir: Path, name: str, body: str) -> None:
+    plugin_dir.mkdir(exist_ok=True)
+    (plugin_dir / f"{name}.py").write_text(body)
 
 
 def test_load_provider_path_loads_local(tmp_path: Path) -> None:
@@ -35,7 +51,7 @@ def test_load_provider_class_is_instantiated(tmp_path: Path) -> None:
 
     pyproject = dynamic_metadata.loader.process_dynamic_metadata(
         {"name": "test", "dynamic": ["version"]},
-        [{"provider": "class_prov:Provider", "provider-path": str(plugin_dir)}],
+        [{"provider": {"path": str(plugin_dir), "module": "class_prov:Provider"}}],
         "wheel",
     )
 
@@ -67,7 +83,7 @@ def test_template_basic() -> None:
         },
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "requires-python",
                 "result": ">={project[version]}",
             },
@@ -89,17 +105,17 @@ def test_template_order_reads_earlier_result() -> None:
         },
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "requires-python",
                 "result": ">={project[version]}",
             },
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "license",
                 "result": "{project[requires-python]}",
             },
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "readme",
                 "result": {"file": "{project[license]}"},
             },
@@ -121,12 +137,12 @@ def test_forward_reference_raises() -> None:
             {"name": "test", "dynamic": ["requires-python", "version"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.template",
+                    "provider": "dynamic_metadata.template",
                     "field": "requires-python",
                     "result": ">={project[version]}",
                 },
                 {
-                    "provider": "dynamic_metadata.plugins.template",
+                    "provider": "dynamic_metadata.template",
                     "field": "version",
                     "result": "1.0",
                 },
@@ -141,12 +157,12 @@ def test_multiple_entries_same_field_merge_in_order() -> None:
         {"name": "test", "dynamic": ["dependencies"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "dependencies",
                 "result": ["a"],
             },
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "dependencies",
                 "result": ["b"],
             },
@@ -164,12 +180,12 @@ def test_scalar_field_second_entry_replaces() -> None:
         {"name": "test", "dynamic": ["version"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "version",
                 "result": "1.0",
             },
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "version",
                 "result": "{project[version]}.post1",
             },
@@ -191,7 +207,7 @@ def test_provider_sets_multiple_fields(tmp_path: Path) -> None:
 
     pyproject = dynamic_metadata.loader.process_dynamic_metadata(
         {"name": "test", "dynamic": ["version", "requires-python"]},
-        [{"provider": "multi_prov", "provider-path": str(plugin_dir)}],
+        [{"provider": {"path": str(plugin_dir), "module": "multi_prov"}}],
         "wheel",
     )
 
@@ -210,7 +226,7 @@ def test_unknown_field_rejected(tmp_path: Path) -> None:
     with pytest.raises(KeyError, match="settable"):
         dynamic_metadata.loader.process_dynamic_metadata(
             {"name": "test", "dynamic": ["version"]},
-            [{"provider": "bad_field_prov", "provider-path": str(plugin_dir)}],
+            [{"provider": {"path": str(plugin_dir), "module": "bad_field_prov"}}],
             "wheel",
         )
 
@@ -225,7 +241,7 @@ def test_field_not_declared_dynamic_rejected(tmp_path: Path) -> None:
     with pytest.raises(KeyError, match=r"project\.dynamic"):
         dynamic_metadata.loader.process_dynamic_metadata(
             {"name": "test", "dynamic": []},
-            [{"provider": "undeclared_prov", "provider-path": str(plugin_dir)}],
+            [{"provider": {"path": str(plugin_dir), "module": "undeclared_prov"}}],
             "wheel",
         )
 
@@ -238,12 +254,12 @@ def test_template_entry_points() -> None:
         },
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "version",
                 "result": "1.2.3",
             },
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "entry-points",
                 "result": {
                     "my_group": {"my_point": "my_app:script_{project[version]}"}
@@ -267,7 +283,7 @@ def test_regex() -> None:
         },
         [
             {
-                "provider": "dynamic_metadata.plugins.regex",
+                "provider": "dynamic_metadata.regex",
                 "field": "requires-python",
                 "input": "pyproject.toml",
                 "regex": r"name = \"(?P<name>.+)\"",
@@ -286,7 +302,7 @@ def test_regex_rejects_unknown_setting() -> None:
             {"name": "test", "version": "0.1.0", "dynamic": ["requires-python"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.regex",
+                    "provider": "dynamic_metadata.regex",
                     "field": "requires-python",
                     "input": "pyproject.toml",
                     "typo": "oops",
@@ -318,8 +334,10 @@ def test_build_state_hook_drives_result(tmp_path: Path) -> None:
             {"name": "test", "dynamic": ["version"]},
             [
                 {
-                    "provider": "build_state_prov:Provider",
-                    "provider-path": str(plugin_dir),
+                    "provider": {
+                        "path": str(plugin_dir),
+                        "module": "build_state_prov:Provider",
+                    },
                 },
             ],
             build_state,
@@ -362,8 +380,8 @@ def test_load_dynamic_metadata_aggregates_requires_and_wheel(
     )
 
     entries = [
-        {"provider": "full_prov:Provider", "provider-path": str(plugin_dir)},
-        {"provider": "bare_prov", "provider-path": str(plugin_dir)},
+        {"provider": {"path": str(plugin_dir), "module": "full_prov:Provider"}},
+        {"provider": {"path": str(plugin_dir), "module": "bare_prov"}},
     ]
 
     requires = []
@@ -397,7 +415,7 @@ def test_pep808_extends_static_dependencies() -> None:
         },
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "dependencies",
                 "result": ["numpy>={project[version]}"],
             },
@@ -421,7 +439,7 @@ def test_pep808_provider_reads_own_static() -> None:
         },
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "dependencies",
                 "result": ["saw:{project[dependencies]}"],
             },
@@ -536,7 +554,7 @@ def test_cli_show(
         'dynamic = ["requires-python"]\n'
         "\n"
         "[[tool.dynamic-metadata]]\n"
-        'provider = "dynamic_metadata.plugins.template"\n'
+        'provider = "dynamic_metadata.template"\n'
         'field = "requires-python"\n'
         'result = ">={project[version]}"\n'
     )
@@ -588,8 +606,8 @@ def test_cli_show_state(
         'dynamic = ["version"]\n'
         "\n"
         "[[tool.dynamic-metadata]]\n"
-        'provider = "state_prov:Provider"\n'
-        f"provider-path = {json.dumps(str(plugin_dir))}\n"
+        f"provider = {{ path = {json.dumps(str(plugin_dir))}, "
+        'module = "state_prov:Provider" }\n'
     )
 
     dynamic_metadata.__main__.main(
@@ -603,7 +621,7 @@ def test_cli_show_state(
 def test_readme_fragment_text_creates_readme() -> None:
     pyproject = dynamic_metadata.loader.process_dynamic_metadata(
         {"name": "test", "dynamic": ["readme"]},
-        [{"provider": "dynamic_metadata.plugins.readme_fragment", "text": "# Hello\n"}],
+        [{"provider": "dynamic_metadata.readme_fragment", "text": "# Hello\n"}],
         "wheel",
     )
 
@@ -616,10 +634,10 @@ def test_readme_fragment_appends_in_order() -> None:
         {"name": "test", "dynamic": ["readme"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.readme_fragment",
+                "provider": "dynamic_metadata.readme_fragment",
                 "text": "# Title\n\n",
             },
-            {"provider": "dynamic_metadata.plugins.readme_fragment", "text": "Body.\n"},
+            {"provider": "dynamic_metadata.readme_fragment", "text": "Body.\n"},
         ],
         "wheel",
     )
@@ -636,11 +654,11 @@ def test_readme_fragment_content_type_carried() -> None:
         {"name": "test", "dynamic": ["readme"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.readme_fragment",
+                "provider": "dynamic_metadata.readme_fragment",
                 "content-type": "text/x-rst",
                 "text": "Title\n",
             },
-            {"provider": "dynamic_metadata.plugins.readme_fragment", "text": "more\n"},
+            {"provider": "dynamic_metadata.readme_fragment", "text": "more\n"},
         ],
         "wheel",
     )
@@ -659,7 +677,7 @@ def test_readme_fragment_file_start_after_end_before(tmp_path: Path) -> None:
         {"name": "test", "dynamic": ["readme"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.readme_fragment",
+                "provider": "dynamic_metadata.readme_fragment",
                 "path": str(src),
                 "start-after": "<!-- start -->\n",
                 "end-before": "<!-- end -->",
@@ -679,7 +697,7 @@ def test_readme_fragment_file_start_at_end_at(tmp_path: Path) -> None:
         {"name": "test", "dynamic": ["readme"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.readme_fragment",
+                "provider": "dynamic_metadata.readme_fragment",
                 "path": str(src),
                 "start-at": "## Heading",
                 "end-at": "END",
@@ -699,7 +717,7 @@ def test_readme_fragment_file_pattern(tmp_path: Path) -> None:
         {"name": "test", "dynamic": ["readme"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.readme_fragment",
+                "provider": "dynamic_metadata.readme_fragment",
                 "path": str(src),
                 "pattern": r"(## 1\.0.*?)(?=\n## )",
             }
@@ -716,7 +734,7 @@ def test_readme_fragment_rejects_text_and_path() -> None:
             {"name": "test", "dynamic": ["readme"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.readme_fragment",
+                    "provider": "dynamic_metadata.readme_fragment",
                     "text": "x",
                     "path": "y",
                 }
@@ -729,7 +747,7 @@ def test_readme_fragment_rejects_neither() -> None:
     with pytest.raises(RuntimeError, match="must set 'text' or 'path'"):
         dynamic_metadata.loader.process_dynamic_metadata(
             {"name": "test", "dynamic": ["readme"]},
-            [{"provider": "dynamic_metadata.plugins.readme_fragment"}],
+            [{"provider": "dynamic_metadata.readme_fragment"}],
             "wheel",
         )
 
@@ -740,7 +758,7 @@ def test_readme_fragment_rejects_slicing_without_path() -> None:
             {"name": "test", "dynamic": ["readme"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.readme_fragment",
+                    "provider": "dynamic_metadata.readme_fragment",
                     "text": "x",
                     "start-after": "y",
                 }
@@ -757,7 +775,7 @@ def test_readme_fragment_rejects_both_starts(tmp_path: Path) -> None:
             {"name": "test", "dynamic": ["readme"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.readme_fragment",
+                    "provider": "dynamic_metadata.readme_fragment",
                     "path": str(src),
                     "start-after": "a",
                     "start-at": "b",
@@ -775,7 +793,7 @@ def test_readme_fragment_missing_marker(tmp_path: Path) -> None:
             {"name": "test", "dynamic": ["readme"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.readme_fragment",
+                    "provider": "dynamic_metadata.readme_fragment",
                     "path": str(src),
                     "start-after": "absent",
                 }
@@ -790,7 +808,7 @@ def test_readme_fragment_rejects_unknown_setting() -> None:
             {"name": "test", "dynamic": ["readme"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.readme_fragment",
+                    "provider": "dynamic_metadata.readme_fragment",
                     "text": "x",
                     "typo": "oops",
                 }
@@ -804,11 +822,11 @@ def test_substitute_readme() -> None:
         {"name": "test", "dynamic": ["readme"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.readme_fragment",
+                "provider": "dynamic_metadata.readme_fragment",
                 "text": "see #42 now\n",
             },
             {
-                "provider": "dynamic_metadata.plugins.substitute",
+                "provider": "dynamic_metadata.substitute",
                 "field": "readme",
                 "pattern": r"#(\d+)",
                 "replacement": r"[#\1](https://x/\1)",
@@ -826,12 +844,12 @@ def test_substitute_str_field() -> None:
         {"name": "test", "version": "0.1.0", "dynamic": ["description"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "description",
                 "result": "Version {project[version]}",
             },
             {
-                "provider": "dynamic_metadata.plugins.substitute",
+                "provider": "dynamic_metadata.substitute",
                 "field": "description",
                 "pattern": "Version",
                 "replacement": "v",
@@ -849,12 +867,12 @@ def test_substitute_format_references_field() -> None:
         {"name": "test", "version": "1.2.3", "dynamic": ["description"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "description",
                 "result": "placeholder",
             },
             {
-                "provider": "dynamic_metadata.plugins.substitute",
+                "provider": "dynamic_metadata.substitute",
                 "field": "description",
                 "pattern": "placeholder",
                 "replacement": "v{project[version]}",
@@ -874,12 +892,12 @@ def test_substitute_format_with_backreference() -> None:
         {"name": "test", "version": "1.2.3", "dynamic": ["description"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "description",
                 "result": "#42",
             },
             {
-                "provider": "dynamic_metadata.plugins.substitute",
+                "provider": "dynamic_metadata.substitute",
                 "field": "description",
                 "pattern": r"#(\d+)",
                 "replacement": r"{project[version]}-\1",
@@ -899,12 +917,12 @@ def test_substitute_no_format_keeps_braces_literal() -> None:
         {"name": "test", "dynamic": ["description"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.template",
+                "provider": "dynamic_metadata.template",
                 "field": "description",
                 "result": "placeholder",
             },
             {
-                "provider": "dynamic_metadata.plugins.substitute",
+                "provider": "dynamic_metadata.substitute",
                 "field": "description",
                 "pattern": "placeholder",
                 "replacement": "x{y}z",
@@ -922,12 +940,12 @@ def test_substitute_format_rejects_non_bool() -> None:
             {"name": "test", "dynamic": ["description"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.template",
+                    "provider": "dynamic_metadata.template",
                     "field": "description",
                     "result": "placeholder",
                 },
                 {
-                    "provider": "dynamic_metadata.plugins.substitute",
+                    "provider": "dynamic_metadata.substitute",
                     "field": "description",
                     "pattern": "placeholder",
                     "replacement": "x",
@@ -943,11 +961,11 @@ def test_substitute_ignore_case() -> None:
         {"name": "test", "dynamic": ["readme"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.readme_fragment",
+                "provider": "dynamic_metadata.readme_fragment",
                 "text": "Hello HELLO\n",
             },
             {
-                "provider": "dynamic_metadata.plugins.substitute",
+                "provider": "dynamic_metadata.substitute",
                 "field": "readme",
                 "pattern": "hello",
                 "replacement": "hi",
@@ -966,7 +984,7 @@ def test_substitute_rejects_non_scalar() -> None:
             {"name": "test", "dynamic": ["keywords"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.substitute",
+                    "provider": "dynamic_metadata.substitute",
                     "field": "keywords",
                     "pattern": "a",
                     "replacement": "b",
@@ -982,7 +1000,7 @@ def test_substitute_requires_existing_value() -> None:
             {"name": "test", "dynamic": ["readme"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.substitute",
+                    "provider": "dynamic_metadata.substitute",
                     "field": "readme",
                     "pattern": "a",
                     "replacement": "b",
@@ -998,11 +1016,11 @@ def test_substitute_rejects_unknown_setting() -> None:
             {"name": "test", "dynamic": ["readme"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.readme_fragment",
+                    "provider": "dynamic_metadata.readme_fragment",
                     "text": "hi\n",
                 },
                 {
-                    "provider": "dynamic_metadata.plugins.substitute",
+                    "provider": "dynamic_metadata.substitute",
                     "field": "readme",
                     "pattern": "a",
                     "replacement": "b",
@@ -1018,7 +1036,7 @@ def test_static_sets_fields() -> None:
         {"name": "test", "dynamic": ["version", "description", "keywords"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.static",
+                "provider": "dynamic_metadata.static",
                 "version": "1.2.3",
                 "description": "My package",
                 "keywords": ["a", "b"],
@@ -1039,11 +1057,11 @@ def test_static_then_substitute() -> None:
         {"name": "test", "dynamic": ["version"]},
         [
             {
-                "provider": "dynamic_metadata.plugins.static",
+                "provider": "dynamic_metadata.static",
                 "version": "1.2.3-beta",
             },
             {
-                "provider": "dynamic_metadata.plugins.substitute",
+                "provider": "dynamic_metadata.substitute",
                 "field": "version",
                 "pattern": "-beta$",
                 "replacement": "b0",
@@ -1061,7 +1079,7 @@ def test_static_rejects_unknown_field() -> None:
             {"name": "test", "dynamic": ["version"]},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.static",
+                    "provider": "dynamic_metadata.static",
                     "descriptions": "typo",
                 }
             ],
@@ -1075,9 +1093,251 @@ def test_static_field_must_be_dynamic() -> None:
             {"name": "test", "dynamic": []},
             [
                 {
-                    "provider": "dynamic_metadata.plugins.static",
+                    "provider": "dynamic_metadata.static",
                     "version": "1.2.3",
                 }
             ],
             "wheel",
         )
+
+
+def test_regex_short_name() -> None:
+    # The bundled plugins are registered under dynamic_metadata-prefixed names,
+    # so the registered name resolves via the entry-point group to the module.
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "version": "0.1.0", "dynamic": ["requires-python"]},
+        [
+            {
+                "provider": "dynamic_metadata.regex",
+                "field": "requires-python",
+                "input": "pyproject.toml",
+                "regex": r"name = \"(?P<name>.+)\"",
+                "result": ">={name}",
+            },
+        ],
+        "wheel",
+    )
+
+    assert pyproject["requires-python"] == ">=dynamic-metadata"
+
+
+def test_entry_point_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_provider(
+        tmp_path,
+        "ep_mod",
+        "def dynamic_metadata(settings, project):\n    return {'version': '1.0'}\n",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        compat_metadata,
+        "entry_points",
+        _fake_group(
+            EntryPoint("mymod", "ep_mod", dynamic_metadata.loader.PROVIDER_GROUP)
+        ),
+    )
+
+    provider = dynamic_metadata.loader.load_provider("mymod")
+    assert provider.dynamic_metadata({}, {}) == {"version": "1.0"}
+
+
+def test_entry_point_class_is_instantiated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_provider(
+        tmp_path,
+        "ep_cls",
+        "class Provider:\n"
+        "    def dynamic_metadata(self, settings, project):\n"
+        "        return {'version': '2.0'}\n",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        compat_metadata,
+        "entry_points",
+        _fake_group(
+            EntryPoint("cls", "ep_cls:Provider", dynamic_metadata.loader.PROVIDER_GROUP)
+        ),
+    )
+
+    import ep_cls  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    provider = dynamic_metadata.loader.load_provider("cls")
+    assert isinstance(provider, ep_cls.Provider)
+
+
+def test_entry_point_instance_not_called(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An entry point may point at an already-instantiated object; it is used as
+    # is rather than called (a class would be instantiated).
+    _write_provider(
+        tmp_path,
+        "ep_inst",
+        "class Provider:\n"
+        "    def dynamic_metadata(self, settings, project):\n"
+        "        return {'version': '3.0'}\n"
+        "INSTANCE = Provider()\n",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        compat_metadata,
+        "entry_points",
+        _fake_group(
+            EntryPoint(
+                "inst", "ep_inst:INSTANCE", dynamic_metadata.loader.PROVIDER_GROUP
+            )
+        ),
+    )
+
+    import ep_inst  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    provider = dynamic_metadata.loader.load_provider("inst")
+    assert provider is ep_inst.INSTANCE
+
+
+def test_entry_point_used_not_raw_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Without provider-path, a name is resolved through the entry-point group
+    # only; a same-named importable module is never imported directly.
+    _write_provider(
+        tmp_path,
+        "winning",
+        "def dynamic_metadata(settings, project):\n    return {'version': 'ep'}\n",
+    )
+    _write_provider(
+        tmp_path,
+        "collide",
+        "def dynamic_metadata(settings, project):\n    return {'version': 'module'}\n",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        compat_metadata,
+        "entry_points",
+        _fake_group(
+            EntryPoint("collide", "winning", dynamic_metadata.loader.PROVIDER_GROUP)
+        ),
+    )
+
+    provider = dynamic_metadata.loader.load_provider("collide")
+    assert provider.dynamic_metadata({}, {}) == {"version": "ep"}
+
+
+def test_raw_import_rejected_without_provider_path() -> None:
+    # The module-path form requires the inline table: an importable module that
+    # is not a registered entry point is not accepted as a bare string.
+    with pytest.raises(ModuleNotFoundError, match="Unknown provider"):
+        dynamic_metadata.loader.load_provider("dynamic_metadata.plugins.regex")
+
+
+def test_provider_inline_table_local(tmp_path: Path) -> None:
+    # The inline table {path, module} imports a local plugin from a directory.
+    _write_provider(
+        tmp_path,
+        "inline_prov",
+        "def dynamic_metadata(settings, project):\n    return {'version': '9.9'}\n",
+    )
+
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["version"]},
+        [{"provider": {"path": str(tmp_path), "module": "inline_prov"}}],
+        "wheel",
+    )
+
+    assert pyproject["version"] == "9.9"
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        pytest.param({"module": "x"}, id="missing-path"),
+        pytest.param({"path": "x"}, id="missing-module"),
+        pytest.param({"path": "x", "module": "y", "extra": "z"}, id="extra-key"),
+        pytest.param(42, id="wrong-type"),
+    ],
+)
+def test_provider_inline_table_rejects_bad_shape(spec: Any) -> None:
+    with pytest.raises(ValueError, match="inline table with exactly"):
+        list(dynamic_metadata.loader.load_dynamic_metadata([{"provider": spec}]))
+
+
+def test_entry_point_duplicate_name_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    group = dynamic_metadata.loader.PROVIDER_GROUP
+    monkeypatch.setattr(
+        compat_metadata,
+        "entry_points",
+        _fake_group(
+            EntryPoint("dup", "a.mod", group),
+            EntryPoint("dup", "b.mod", group),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="multiple distributions"):
+        dynamic_metadata.loader.load_provider("dup")
+
+
+def test_entry_point_load_failure_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    group = dynamic_metadata.loader.PROVIDER_GROUP
+    monkeypatch.setattr(
+        compat_metadata,
+        "entry_points",
+        _fake_group(EntryPoint("broken", "no_such_module_xyz", group)),
+    )
+
+    with pytest.raises(ImportError, match="Could not load provider 'broken'"):
+        dynamic_metadata.loader.load_provider("broken")
+
+
+def test_provider_path_ignores_entry_point(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # provider-path forces a raw import; a registered entry point of the same
+    # name is not consulted.
+    _write_provider(
+        tmp_path,
+        "local",
+        "def dynamic_metadata(settings, project):\n    return {'version': 'local'}\n",
+    )
+    monkeypatch.setattr(
+        compat_metadata,
+        "entry_points",
+        _fake_group(
+            EntryPoint(
+                "local",
+                "dynamic_metadata.plugins.static",
+                dynamic_metadata.loader.PROVIDER_GROUP,
+            )
+        ),
+    )
+
+    provider = dynamic_metadata.loader.load_provider("local", str(tmp_path))
+    assert provider.dynamic_metadata({}, {}) == {"version": "local"}
+
+
+def test_unknown_provider_suggests(monkeypatch: pytest.MonkeyPatch) -> None:
+    group = dynamic_metadata.loader.PROVIDER_GROUP
+    monkeypatch.setattr(
+        compat_metadata,
+        "entry_points",
+        _fake_group(EntryPoint("regex", "dynamic_metadata.plugins.regex", group)),
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="did you mean 'regex'"):
+        dynamic_metadata.loader.load_provider("regx")
+
+
+def test_list_providers_includes_bundled() -> None:
+    providers = dynamic_metadata.loader.list_providers()
+    assert "dynamic_metadata.regex" in providers
+    assert "dynamic_metadata.plugins.regex" in providers["dynamic_metadata.regex"]
+
+
+def test_cli_providers(capsys: pytest.CaptureFixture[str]) -> None:
+    dynamic_metadata.__main__.main(["providers"])
+    out = capsys.readouterr().out
+    assert "dynamic_metadata.regex" in out
+    assert "dynamic_metadata.template" in out

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -35,7 +35,9 @@ def test_load_provider_path_loads_local(tmp_path: Path) -> None:
         "def dynamic_metadata(settings, project):\n    return {'version': '1.2.3'}\n"
     )
 
-    provider = dynamic_metadata.loader.load_provider("local_prov_ok", str(plugin_dir))
+    provider = dynamic_metadata.loader.load_provider(
+        {"path": str(plugin_dir), "module": "local_prov_ok"}
+    )
     assert provider.dynamic_metadata({}, {}) == {"version": "1.2.3"}
 
 
@@ -72,7 +74,9 @@ def test_load_provider_path_not_shadowed(
     empty = tmp_path / "empty"
     empty.mkdir()
     with pytest.raises(ModuleNotFoundError):
-        dynamic_metadata.loader.load_provider("shadow_prov", str(empty))
+        dynamic_metadata.loader.load_provider(
+            {"path": str(empty), "module": "shadow_prov"}
+        )
 
 
 def test_template_basic() -> None:
@@ -1296,8 +1300,8 @@ def test_entry_point_load_failure_wrapped(
 def test_provider_path_ignores_entry_point(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # provider-path forces a raw import; a registered entry point of the same
-    # name is not consulted.
+    # The inline table forces a local import; a registered entry point of the
+    # same name is not consulted.
     _write_provider(
         tmp_path,
         "local",
@@ -1315,7 +1319,9 @@ def test_provider_path_ignores_entry_point(
         ),
     )
 
-    provider = dynamic_metadata.loader.load_provider("local", str(tmp_path))
+    provider = dynamic_metadata.loader.load_provider(
+        {"path": str(tmp_path), "module": "local"}
+    )
     assert provider.dynamic_metadata({}, {}) == {"version": "local"}
 
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import dynamic_metadata.__main__
+import dynamic_metadata.discovery
 import dynamic_metadata.loader
 import dynamic_metadata.plugins
 from dynamic_metadata._compat import metadata as compat_metadata
@@ -1331,7 +1332,7 @@ def test_unknown_provider_suggests(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_list_providers_includes_bundled() -> None:
-    providers = dynamic_metadata.loader.list_providers()
+    providers = dynamic_metadata.discovery.list_providers()
     assert "dynamic_metadata.regex" in providers
     assert "dynamic_metadata.plugins.regex" in providers["dynamic_metadata.regex"]
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds an entry-point discovery mechanism for dynamic-metadata providers, replacing the import-path + `provider-path` scheme with a two-shape `provider` config. Follows up on the "could we provide an entry point system?" design discussion.

## What changed

`provider` now takes one of two shapes:

```toml
# installed plugin — a name registered in the `dynamic_metadata.provider` group
provider = "dynamic_metadata.regex"

# local plugin inside the project — inline table (replaces `provider-path`)
provider = { path = "scripts", module = "my_plugin" }   # module may be "mod:Class"
```

- **Installed plugins** register a name in the `dynamic_metadata.provider` entry-point group. Bundled plugins register under `dynamic_metadata.`-prefixed names; third-party plugins are encouraged to prefix with their own package (the group is shared, and a name registered by two distributions is a hard error).
- **Local plugins** use the inline `{ path, module }` table. The raw module-path form is *only* accepted this way — there is no bare-import fallback.
- Unknown names raise with a `did you mean …?` suggestion.

## For each audience

- **Plugin authors**: hooks unchanged. To get a name, add one `[project.entry-points."dynamic_metadata.provider"]` table to your own `pyproject.toml`. Loose in-project scripts still need no packaging (inline table). No runtime dependency on this package either way.
- **Backends**: no new required API — resolution is internal to the loader; `process_dynamic_metadata` / `load_dynamic_metadata` signatures are unchanged. New optional `list_providers()` for diagnostics.
- **Schema**: `provider` is now a `oneOf` (string, or `{path, module}` object).

## Notable bits

- New `_compat.metadata.entry_points` shim handles the 3.8/3.9-vs-3.10+ API split without tripping `filterwarnings = error`.
- `list_providers()` + `dynamic-metadata providers` CLI subcommand.
- `RESERVED_KEYS` shrank to just `{provider}`.

## Testing

`uv run pytest` (80 passed), `mypy --strict`, and `prek -a` all green. New tests cover entry-point resolution (module/class/singleton/import-failure/duplicate), the inline-table form and its validation, rejection of the raw-import form without a path, and the discovery helper + CLI.

## Open questions

- Design is still WiP (per the repo). Naming (`module` key, `dynamic_metadata.`-prefixed provider names) and the drop of `provider-path` were chosen in discussion but are easy to revisit.