### PR TITLE
refactor: move plugin protocols into protocols.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,11 @@ stashes it, typically on `self`; the loader detects it via
 `dynamic_wheel(settings) -> dict[str, bool]` (per-field METADATA 2.2 dynamic
 status; version must be false) and
 `get_requires_for_dynamic_metadata(settings) -> list[str]` (extra build
-requirements). Protocols are defined in `loader.py` (`DynamicMetadataProtocol`
-and subclasses). There is no `field` argument: generic plugins (`regex`,
-`template`) read their target from a `field` setting; single-purpose plugins
-hardcode it.
+requirements). Protocols are defined in `protocols.py`
+(`DynamicMetadataProtocol` and subclasses), along with the `BuildState` type and
+`BUILD_STATES` set; `loader.py` imports them. There is no `field` argument:
+generic plugins (`regex`, `template`) read their target from a `field` setting;
+single-purpose plugins hardcode it.
 
 ### Field taxonomy — `info.py`
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -20,13 +20,13 @@ The protocols a provider may implement. Every provider satisfies
 `DynamicMetadataProtocol`; the others add optional hooks.
 
 ```{eval-rst}
-.. autoclass:: dynamic_metadata.loader.DynamicMetadataProtocol
+.. autoclass:: dynamic_metadata.protocols.DynamicMetadataProtocol
    :members:
-.. autoclass:: dynamic_metadata.loader.DynamicMetadataBuildStateProtocol
+.. autoclass:: dynamic_metadata.protocols.DynamicMetadataBuildStateProtocol
    :members:
-.. autoclass:: dynamic_metadata.loader.DynamicMetadataRequirementsProtocol
+.. autoclass:: dynamic_metadata.protocols.DynamicMetadataRequirementsProtocol
    :members:
-.. autoclass:: dynamic_metadata.loader.DynamicMetadataWheelProtocol
+.. autoclass:: dynamic_metadata.protocols.DynamicMetadataWheelProtocol
    :members:
 ```
 

--- a/docs/backend_authors.md
+++ b/docs/backend_authors.md
@@ -30,7 +30,8 @@ and producing the final `[project]` metadata. Wire them in like this:
 `build_state` is the string you pass into the loader so a provider can tell
 which build it is taking part in (see
 [Telling a provider the build state](#telling-a-provider-the-build-state)). It
-must be one of the five values above (`dynamic_metadata.loader.BUILD_STATES`).
+must be one of the five values above
+(`dynamic_metadata.protocols.BUILD_STATES`).
 
 Run all hooks from the same directory PEP 517 uses (the project root), since
 plugins resolve relative paths like `input = "src/pkg/__init__.py"` against the
@@ -62,10 +63,8 @@ anything it asks for. This is how a provider that wraps an external tool gets
 its dependency installed without the user listing it.
 
 ```python
-from dynamic_metadata.loader import (
-    DynamicMetadataRequirementsProtocol,
-    load_dynamic_metadata,
-)
+from dynamic_metadata.loader import load_dynamic_metadata
+from dynamic_metadata.protocols import DynamicMetadataRequirementsProtocol
 
 
 def collect_requires(entries):
@@ -108,10 +107,8 @@ and the wheel built from it. Ask each provider which of its fields are dynamic
 in that sense via the optional `dynamic_wheel` hook:
 
 ```python
-from dynamic_metadata.loader import (
-    DynamicMetadataWheelProtocol,
-    load_dynamic_metadata,
-)
+from dynamic_metadata.loader import load_dynamic_metadata
+from dynamic_metadata.protocols import DynamicMetadataWheelProtocol
 
 
 def dynamic_wheel_fields(entries):

--- a/src/dynamic_metadata/__main__.py
+++ b/src/dynamic_metadata/__main__.py
@@ -7,12 +7,13 @@ from typing import TYPE_CHECKING, cast
 
 from ._compat import tomllib
 from .discovery import list_providers
-from .loader import BUILD_STATES, process_dynamic_metadata
+from .loader import process_dynamic_metadata
+from .protocols import BUILD_STATES
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from .loader import BuildState
+    from .protocols import BuildState
 
 __all__ = ["main"]
 

--- a/src/dynamic_metadata/loader.py
+++ b/src/dynamic_metadata/loader.py
@@ -12,11 +12,7 @@ from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Literal,
-    Protocol,
     cast,
-    get_args,
-    runtime_checkable,
 )
 
 from ._compat import metadata
@@ -28,11 +24,12 @@ from .info import (
     LIST_STR_FIELDS,
     SCALAR_FIELDS,
 )
-
-BuildState = Literal[
-    "sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"
-]
-BUILD_STATES: frozenset[str] = frozenset(get_args(BuildState))
+from .protocols import (
+    BUILD_STATES,
+    BuildState,
+    DynamicMetadataBuildStateProtocol,
+    DynamicMetadataProtocol,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
@@ -42,7 +39,6 @@ if TYPE_CHECKING:
 
 
 __all__ = [
-    "BuildState",
     "load_dynamic_metadata",
     "load_provider",
     "process_dynamic_metadata",
@@ -51,32 +47,6 @@ __all__ = [
 
 def __dir__() -> list[str]:
     return __all__
-
-
-@runtime_checkable
-class DynamicMetadataProtocol(Protocol):
-    def dynamic_metadata(
-        self,
-        settings: Mapping[str, Any],
-        project: Mapping[str, Any],
-    ) -> dict[str, Any]: ...
-
-
-@runtime_checkable
-class DynamicMetadataBuildStateProtocol(DynamicMetadataProtocol, Protocol):
-    def build_state(self, build_state: BuildState) -> None: ...
-
-
-@runtime_checkable
-class DynamicMetadataRequirementsProtocol(DynamicMetadataProtocol, Protocol):
-    def get_requires_for_dynamic_metadata(
-        self, settings: Mapping[str, Any]
-    ) -> list[str]: ...
-
-
-@runtime_checkable
-class DynamicMetadataWheelProtocol(DynamicMetadataProtocol, Protocol):
-    def dynamic_wheel(self, settings: Mapping[str, Any]) -> dict[str, bool]: ...
 
 
 # Entry-point group a plugin distribution registers a named provider under. The

--- a/src/dynamic_metadata/protocols.py
+++ b/src/dynamic_metadata/protocols.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Protocol,
+    get_args,
+    runtime_checkable,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = [
+    "BUILD_STATES",
+    "BuildState",
+    "DynamicMetadataBuildStateProtocol",
+    "DynamicMetadataProtocol",
+    "DynamicMetadataRequirementsProtocol",
+    "DynamicMetadataWheelProtocol",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+BuildState = Literal[
+    "sdist", "wheel", "editable", "metadata_wheel", "metadata_editable"
+]
+BUILD_STATES: frozenset[str] = frozenset(get_args(BuildState))
+
+
+@runtime_checkable
+class DynamicMetadataProtocol(Protocol):
+    def dynamic_metadata(
+        self,
+        settings: Mapping[str, Any],
+        project: Mapping[str, Any],
+    ) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class DynamicMetadataBuildStateProtocol(DynamicMetadataProtocol, Protocol):
+    def build_state(self, build_state: BuildState) -> None: ...
+
+
+@runtime_checkable
+class DynamicMetadataRequirementsProtocol(DynamicMetadataProtocol, Protocol):
+    def get_requires_for_dynamic_metadata(
+        self, settings: Mapping[str, Any]
+    ) -> list[str]: ...
+
+
+@runtime_checkable
+class DynamicMetadataWheelProtocol(DynamicMetadataProtocol, Protocol):
+    def dynamic_wheel(self, settings: Mapping[str, Any]) -> dict[str, bool]: ...

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -11,6 +11,7 @@ import dynamic_metadata.__main__
 import dynamic_metadata.discovery
 import dynamic_metadata.loader
 import dynamic_metadata.plugins
+import dynamic_metadata.protocols
 from dynamic_metadata._compat import metadata as compat_metadata
 
 if TYPE_CHECKING:
@@ -334,7 +335,7 @@ def test_build_state_hook_drives_result(tmp_path: Path) -> None:
         "        return {'version': 'reused'}\n"
     )
 
-    def run(build_state: dynamic_metadata.loader.BuildState) -> Any:
+    def run(build_state: dynamic_metadata.protocols.BuildState) -> Any:
         return dynamic_metadata.loader.process_dynamic_metadata(
             {"name": "test", "dynamic": ["version"]},
             [
@@ -394,10 +395,12 @@ def test_load_dynamic_metadata_aggregates_requires_and_wheel(
     for provider, settings in dynamic_metadata.loader.load_dynamic_metadata(entries):
         if isinstance(
             provider,
-            dynamic_metadata.loader.DynamicMetadataRequirementsProtocol,
+            dynamic_metadata.protocols.DynamicMetadataRequirementsProtocol,
         ):
             requires += provider.get_requires_for_dynamic_metadata(settings)
-        if isinstance(provider, dynamic_metadata.loader.DynamicMetadataWheelProtocol):
+        if isinstance(
+            provider, dynamic_metadata.protocols.DynamicMetadataWheelProtocol
+        ):
             dynamic_wheel.update(provider.dynamic_wheel(settings))
 
     assert requires == ["some-dep>=1"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Extract the plugin protocols into their own module so `loader.py` stays focused on loading/resolution.

## What changed

- **New `src/dynamic_metadata/protocols.py`** — holds the four `runtime_checkable` protocols (`DynamicMetadataProtocol`, `DynamicMetadataBuildStateProtocol`, `DynamicMetadataRequirementsProtocol`, `DynamicMetadataWheelProtocol`) plus the `BuildState` literal and `BUILD_STATES` set the `build_state` hook is typed against. It's a leaf module with no dependency on `loader.py`.
- **`loader.py`** — removed those definitions; imports the two protocols and the build-state names it uses. Dropped `BuildState` from its `__all__`.
- **`__main__.py`** — imports `BUILD_STATES`/`BuildState` from `.protocols`.
- **References updated to the new canonical location**: `tests/test_package.py`, `docs/api/index.md` (autoclass directives), `docs/backend_authors.md` (import examples + `BUILD_STATES` mention), and `AGENTS.md`.

## Notes

`protocols.py` is now the canonical home rather than re-exporting from `loader.py`. If keeping `dynamic_metadata.loader.DynamicMetadataProtocol` importable for existing backend-author consumers matters, re-exports can be added — happy to do so.

## Verification

- `uv run pytest` — 80 passed
- `prek -a` — clean (mypy included)