### PR TITLE
feat: add pin_installed plugin for build-time version pinning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,15 @@ encouraged to reuse or vendor.
   `__version__`/`VERSION`).
 - `template.py` — `str.format` substitution using `{project[...]}`,
   demonstrating cross-field references (reading earlier entries' results).
+- `static.py` — settings returned verbatim as fields (gives a later entry a
+  dynamic value to transform).
+- `substitute.py` — regex substitution on a scalar field produced by an earlier
+  entry.
+- `readme_fragment.py` — build `readme` from ordered fragments, one per entry.
+- `pin_installed.py` — pin `dependencies` to build-environment versions via
+  templates like `"torch==x.x.*"` (`x` = installed release component, `x+N`,
+  trailing `*`); implements `dynamic_wheel` (dependencies are Dynamic in the
+  SDist) and `get_requires_for_dynamic_metadata` (the bare names).
 
 ### Schema — `schema.py` + `resources/toml_schema.json`
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The documentation is split by audience:
   — configure plugins in `pyproject.toml`.
 - **[Bundled plugins](https://dynamic-metadata.readthedocs.io/en/latest/plugins.html)**
   — the plugins shipped with this package (`regex`, `template`, `static`,
-  `fragment`, `substitute`).
+  `readme_fragment`, `substitute`, `pin_installed`).
 - **[For plugin authors](https://dynamic-metadata.readthedocs.io/en/latest/plugin_authors.html)**
   — implement the hooks; no runtime dependency on this package required.
 - **[For backend authors](https://dynamic-metadata.readthedocs.io/en/latest/backend_authors.html)**

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,10 +1,11 @@
 # Bundled plugins
 
-This package ships five plugins. `regex`, `template`, and `substitute` are
+This package ships six plugins. `regex`, `template`, and `substitute` are
 generic — they read their target from a `field` setting. `static` writes values
-straight from its settings, and `readme_fragment` is single-purpose and always
-writes `readme`. Because they live inside `dynamic-metadata`, you must add
-`dynamic-metadata` to your `[build-system].requires` to use them.
+straight from its settings; `readme_fragment` and `pin_installed` are
+single-purpose and always write `readme` and `dependencies` respectively.
+Because they live inside `dynamic-metadata`, you must add `dynamic-metadata` to
+your `[build-system].requires` to use them.
 
 Each registers a provider name of `dynamic_metadata.` plus the heading below, so
 the `regex` plugin is `provider = "dynamic_metadata.regex"`. The examples use
@@ -156,6 +157,56 @@ Settings (all values are strings):
 
 Slicing is applied in order: start, then end, then `pattern`. A missing marker
 or a non-matching `pattern` raises a `RuntimeError`.
+
+## `pin_installed`
+
+`dynamic_metadata.plugins.pin_installed` pins runtime dependencies to the
+version of a package installed in the build environment. This is the classic
+compiled-extension workflow: a wheel built against the pytorch (or historically
+numpy) ABI must require a matching version at runtime, and that version is only
+known when the wheel is built.
+
+```toml
+[project]
+dynamic = ["dependencies"]
+
+[[tool.dynamic-metadata]]
+provider = "dynamic_metadata.pin_installed"
+packages = ["torch==x.x.*"]
+```
+
+Settings:
+
+| Setting    | Required | Description                                                              |
+| ---------- | -------- | ------------------------------------------------------------------------ |
+| `packages` | yes      | A list of requirement templates, resolved against the build environment. |
+
+Each template is a distribution name followed by a specifier set whose version
+components are, dot-separated:
+
+- `x` — the corresponding release component of the installed version (`0` if the
+  release is shorter). Epoch, pre/post/dev markers, and local version segments
+  (`+cu126`) are ignored.
+- `x+N` — that component plus `N`, for an upper bound like `<x+1`.
+- `*` — a literal PEP 440 wildcard; only valid as the last component with `==`
+  or `!=`.
+- a literal number, passed through.
+
+With torch 2.7.1 installed, `"torch==x.x.*"` resolves to `torch==2.7.*`, and
+`"numpy>=x.x.x,<x+1"` with numpy 1.26.4 resolves to `numpy>=1.26.4,<2` (the
+numpy ABI recommendation). The resolved requirements are appended to any static
+`dependencies` (PEP 808).
+
+The plugin implements both optional collection hooks:
+
+- `get_requires_for_dynamic_metadata` requests the bare names, so the packages
+  are present to be inspected. Constrain which version is used for the _build_
+  in `[build-system].requires` (or by pre-installing with
+  `--no-build-isolation`); the plugin pins the _runtime_ requirement to whatever
+  was resolved.
+- `dynamic_wheel` reports `dependencies` as dynamic, so an SDist's `PKG-INFO`
+  marks `Requires-Dist` as `Dynamic` (METADATA 2.2) — the pins legitimately
+  differ per build environment, so installers must not trust the SDist's value.
 
 ## `substitute`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dynamic-metadata = "dynamic_metadata.schema:get_schema"
 "dynamic_metadata.substitute" = "dynamic_metadata.plugins.substitute"
 "dynamic_metadata.static" = "dynamic_metadata.plugins.static"
 "dynamic_metadata.readme_fragment" = "dynamic_metadata.plugins.readme_fragment"
+"dynamic_metadata.pin_installed" = "dynamic_metadata.plugins.pin_installed"
 
 [tool.flit.sdist]
 include = ["tests/**/*.py", "docs/"]

--- a/src/dynamic_metadata/plugins/pin_installed.py
+++ b/src/dynamic_metadata/plugins/pin_installed.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.metadata
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ["dynamic_metadata", "dynamic_wheel", "get_requires_for_dynamic_metadata"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+KEYS = {"packages"}
+
+# A PEP 508 name followed by a specifier-set template; the name's character
+# class excludes the operator characters, so the split is unambiguous.
+_PACKAGE_RE = re.compile(
+    r"^\s*(?P<name>[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\s*(?P<specifiers>[<>=!~].*)?$"
+)
+_SPECIFIER_RE = re.compile(r"^\s*(?P<op>===|==|!=|<=|>=|<|>|~=)\s*(?P<version>\S+)\s*$")
+_COMPONENT_RE = re.compile(r"^x(?:\+(?P<add>\d+))?$")
+# The release portion of an installed (PEP 440) version; epoch and any
+# pre/post/dev/local suffix are dropped for substitution.
+_RELEASE_RE = re.compile(r"^v?(?:\d+!)?(?P<release>\d+(?:\.\d+)*)")
+
+
+def _packages(settings: Mapping[str, Any]) -> list[str]:
+    if settings.keys() - KEYS:
+        msg = f"Only {KEYS} settings allowed by this plugin"
+        raise RuntimeError(msg)
+    if "packages" not in settings:
+        msg = "Must contain the 'packages' setting listing requirement templates"
+        raise RuntimeError(msg)
+    packages = settings["packages"]
+    if not isinstance(packages, list) or not all(isinstance(p, str) for p in packages):
+        msg = "Setting 'packages' must be a list of strings"
+        raise RuntimeError(msg)
+    return packages
+
+
+def _parse(package: str) -> tuple[str, list[tuple[str, str]]]:
+    """Split a template into the distribution name and (operator, version) pairs."""
+    match = _PACKAGE_RE.match(package)
+    if match is None:
+        msg = f"Invalid package template {package!r}"
+        raise RuntimeError(msg)
+    if match["specifiers"] is None:
+        msg = f"Package template {package!r} must include a specifier like '==x.x.*'"
+        raise RuntimeError(msg)
+    specifiers = []
+    for part in match["specifiers"].split(","):
+        specifier = _SPECIFIER_RE.match(part)
+        if specifier is None:
+            msg = f"Invalid specifier {part.strip()!r} in {package!r}"
+            raise RuntimeError(msg)
+        specifiers.append((specifier["op"], specifier["version"]))
+    return match["name"], specifiers
+
+
+def _fill(op: str, template: str, release: list[str], package: str) -> str:
+    """Substitute the installed release into one version template.
+
+    Each dot-separated component is ``x`` (that release component, 0 when the
+    release is shorter), ``x+N`` (that component plus N, for a ``<x+1`` cap), a
+    literal number, or a trailing ``*`` (PEP 440 wildcard, ``==``/``!=`` only).
+    """
+    parts = template.split(".")
+    out = []
+    for i, part in enumerate(parts):
+        if part == "*":
+            if i != len(parts) - 1:
+                msg = f"'*' must be the last component in {package!r}"
+                raise RuntimeError(msg)
+            if op not in {"==", "!="}:
+                msg = f"'*' requires the '==' or '!=' operator in {package!r}"
+                raise RuntimeError(msg)
+            out.append(part)
+        elif part.isdigit():
+            out.append(part)
+        else:
+            component = _COMPONENT_RE.match(part)
+            if component is None:
+                msg = (
+                    f"Invalid version component {part!r} in {package!r}; "
+                    "use 'x', 'x+N', '*', or a number"
+                )
+                raise RuntimeError(msg)
+            value = int(release[i]) if i < len(release) else 0
+            out.append(str(value + int(component["add"] or 0)))
+    return ".".join(out)
+
+
+def _resolve(package: str) -> str:
+    name, specifiers = _parse(package)
+    try:
+        version = importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError as exc:
+        msg = (
+            f"Package {name!r} is not installed; it must be present in the "
+            "build environment to pin against"
+        )
+        raise RuntimeError(msg) from exc
+    release_match = _RELEASE_RE.match(version)
+    if release_match is None:
+        msg = f"Installed version {version!r} of {name!r} is not PEP 440"
+        raise RuntimeError(msg)
+    release = release_match["release"].split(".")
+    return name + ",".join(
+        op + _fill(op, template, release, package) for op, template in specifiers
+    )
+
+
+def dynamic_metadata(
+    settings: Mapping[str, Any],
+    _project: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {"dependencies": [_resolve(package) for package in _packages(settings)]}
+
+
+def dynamic_wheel(settings: Mapping[str, Any]) -> dict[str, bool]:
+    # The pins depend on what the build environment resolves, so a wheel's
+    # dependencies legitimately differ from the SDist's PKG-INFO.
+    return {"dependencies": bool(_packages(settings))}
+
+
+def get_requires_for_dynamic_metadata(settings: Mapping[str, Any]) -> list[str]:
+    # The bare names, so the packages are present when dynamic_metadata runs;
+    # constrain the build version in [build-system].requires if needed.
+    return [_parse(package)[0] for package in _packages(settings)]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import json
 from importlib.metadata import EntryPoint
 from pathlib import Path
@@ -1413,6 +1414,229 @@ def test_unknown_provider_suggests(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with pytest.raises(ModuleNotFoundError, match="did you mean 'regex'"):
         dynamic_metadata.loader.load_provider("regx")
+
+
+def _fake_versions(**versions: str) -> Callable[[str], str]:
+    """Stand in for importlib.metadata.version with a fixed environment."""
+
+    def version(name: str) -> str:
+        try:
+            return versions[name]
+        except KeyError:
+            raise importlib.metadata.PackageNotFoundError(name) from None
+
+    return version
+
+
+def test_pin_installed_wildcard(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The classic torch pin: match the installed major.minor, any patch. The
+    # local version segment (+cu126) is ignored for substitution.
+    monkeypatch.setattr(
+        importlib.metadata, "version", _fake_versions(torch="2.7.1+cu126")
+    )
+
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["dependencies"]},
+        [
+            {
+                "provider": "dynamic_metadata.pin_installed",
+                "packages": ["torch==x.x.*"],
+            }
+        ],
+        "wheel",
+    )
+
+    assert pyproject["dependencies"] == ["torch==2.7.*"]
+    assert pyproject["dynamic"] == []
+
+
+def test_pin_installed_range_with_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The numpy ABI recommendation: at least the build version, below the next
+    # major. x+1 adds to the substituted component.
+    monkeypatch.setattr(importlib.metadata, "version", _fake_versions(numpy="1.26.4"))
+
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["dependencies"]},
+        [
+            {
+                "provider": "dynamic_metadata.pin_installed",
+                "packages": ["numpy>=x.x.x,<x+1"],
+            }
+        ],
+        "wheel",
+    )
+
+    assert pyproject["dependencies"] == ["numpy>=1.26.4,<2"]
+
+
+def test_pin_installed_multiple_and_static_merge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Pins keep the packages order and append to static dependencies (PEP 808).
+    monkeypatch.setattr(
+        importlib.metadata,
+        "version",
+        _fake_versions(torch="2.7.1", numpy="1.26.4"),
+    )
+
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {
+            "name": "test",
+            "dependencies": ["packaging"],
+            "dynamic": ["dependencies"],
+        },
+        [
+            {
+                "provider": "dynamic_metadata.pin_installed",
+                "packages": ["torch==x.x.*", "numpy~=x.x"],
+            }
+        ],
+        "wheel",
+    )
+
+    assert pyproject["dependencies"] == ["packaging", "torch==2.7.*", "numpy~=1.26"]
+
+
+def test_pin_installed_odd_versions(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A short release pads missing components with 0; epoch and pre-release
+    # suffixes are dropped; literal components pass through.
+    monkeypatch.setattr(
+        importlib.metadata,
+        "version",
+        _fake_versions(short="2.0", fancy="1!3.4.0rc1"),
+    )
+
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["dependencies"]},
+        [
+            {
+                "provider": "dynamic_metadata.pin_installed",
+                "packages": ["short==x.x.x", "fancy>=x.x.0,<x+1"],
+            }
+        ],
+        "wheel",
+    )
+
+    assert pyproject["dependencies"] == ["short==2.0.0", "fancy>=3.4.0,<4"]
+
+
+def test_pin_installed_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(importlib.metadata, "version", _fake_versions())
+
+    with pytest.raises(RuntimeError, match="'torch' is not installed"):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": ["dependencies"]},
+            [
+                {
+                    "provider": "dynamic_metadata.pin_installed",
+                    "packages": ["torch==x.x.*"],
+                }
+            ],
+            "wheel",
+        )
+
+
+def test_pin_installed_real_package() -> None:
+    # One un-mocked run against a distribution guaranteed to be installed.
+    major = importlib.metadata.version("pytest").split(".")[0]
+
+    pyproject = dynamic_metadata.loader.process_dynamic_metadata(
+        {"name": "test", "dynamic": ["dependencies"]},
+        [
+            {
+                "provider": "dynamic_metadata.pin_installed",
+                "packages": ["pytest==x.*"],
+            }
+        ],
+        "wheel",
+    )
+
+    assert pyproject["dependencies"] == [f"pytest=={major}.*"]
+
+
+@pytest.mark.parametrize(
+    ("package", "match"),
+    [
+        pytest.param("torch", "must include a specifier", id="no-specifier"),
+        pytest.param("==x.x", "Invalid package template", id="no-name"),
+        pytest.param("torch=x.x", "Invalid specifier", id="single-equals"),
+        pytest.param("torch==x.*.x", "must be the last component", id="wildcard-mid"),
+        pytest.param("torch>=x.*", "requires the '==' or '!='", id="wildcard-range"),
+        pytest.param("torch==x.y", "Invalid version component", id="bad-component"),
+    ],
+)
+def test_pin_installed_rejects_bad_template(
+    monkeypatch: pytest.MonkeyPatch, package: str, match: str
+) -> None:
+    monkeypatch.setattr(importlib.metadata, "version", _fake_versions(torch="2.7.1"))
+
+    with pytest.raises(RuntimeError, match=match):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": ["dependencies"]},
+            [
+                {
+                    "provider": "dynamic_metadata.pin_installed",
+                    "packages": [package],
+                }
+            ],
+            "wheel",
+        )
+
+
+@pytest.mark.parametrize(
+    ("settings", "match"),
+    [
+        pytest.param({}, "Must contain the 'packages'", id="missing"),
+        pytest.param(
+            {"packages": "torch==x.x.*"}, "must be a list of strings", id="not-list"
+        ),
+        pytest.param({"packages": [42]}, "must be a list of strings", id="not-str"),
+        pytest.param(
+            {"packages": [], "typo": "oops"}, "settings allowed", id="unknown-setting"
+        ),
+    ],
+)
+def test_pin_installed_rejects_bad_settings(
+    settings: dict[str, Any], match: str
+) -> None:
+    with pytest.raises(RuntimeError, match=match):
+        dynamic_metadata.loader.process_dynamic_metadata(
+            {"name": "test", "dynamic": ["dependencies"]},
+            [{"provider": "dynamic_metadata.pin_installed", **settings}],
+            "wheel",
+        )
+
+
+def test_pin_installed_dynamic_wheel() -> None:
+    # Pinned dependencies differ per build environment, so the SDist marks them
+    # Dynamic (METADATA 2.2); with nothing to pin, nothing is dynamic.
+    fields = dynamic_metadata.loader.dynamic_wheel_fields(
+        [
+            {
+                "provider": "dynamic_metadata.pin_installed",
+                "packages": ["torch==x.x.*"],
+            }
+        ]
+    )
+    assert fields == {"dependencies"}
+
+    fields = dynamic_metadata.loader.dynamic_wheel_fields(
+        [{"provider": "dynamic_metadata.pin_installed", "packages": []}]
+    )
+    assert fields == set()
+
+
+def test_pin_installed_get_requires() -> None:
+    # The bare names are requested so the packages exist to be inspected.
+    requires = dynamic_metadata.loader.get_requires_for_dynamic_metadata(
+        [
+            {
+                "provider": "dynamic_metadata.pin_installed",
+                "packages": ["torch==x.x.*", "numpy>=x.x.x,<x+1"],
+            }
+        ]
+    )
+    assert requires == ["torch", "numpy"]
 
 
 def test_list_providers_includes_bundled() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a bundled `pin_installed` plugin for the compiled-extension workflow where a wheel must require the package version it was built against (pytorch today, numpy historically).

`packages` takes requirement templates resolved against the build environment: `x` substitutes the corresponding installed release component, `x+N` adds to it for an upper bound, and a trailing `*` is a literal PEP 440 wildcard. With torch 2.7.1 installed, `"torch==x.x.*"` resolves to `torch==2.7.*`; `"numpy>=x.x.x,<x+1"` with numpy 1.26.4 resolves to `numpy>=1.26.4,<2`.

```toml
[project]
dynamic = ["dependencies"]

[[tool.dynamic-metadata]]
provider = "dynamic_metadata.pin_installed"
packages = ["torch==x.x.*"]
```

The plugin implements both optional collection hooks: `dynamic_wheel` marks `dependencies` as `Dynamic` in the SDist PKG-INFO (METADATA 2.2), since the pins depend on the build environment, and `get_requires_for_dynamic_metadata` returns the bare names so the packages are present to inspect.

Also fixes the README plugin list (`fragment` → `readme_fragment`) and fills in the missing bundled plugins in AGENTS.md.