### PR TITLE
chore: release 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",

--- a/src/dynamic_metadata/__init__.py
+++ b/src/dynamic_metadata/__init__.py
@@ -6,6 +6,6 @@ dynamic-metadata: This project is intended to document dynamic-metadata support.
 
 from __future__ import annotations
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = ("__version__",)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Bumps the version to `0.5.0` and promotes the package from Alpha to Beta (`Development Status :: 4 - Beta`).

---

Changelog:


## Version 0.5.0

Feature release adding four new bundled plugins and the backend collection loops.

### ✨ Features
- **`ast` plugin** (#81) — read a module-level global by name from a Python file via `ast.literal_eval`, without importing it. Values keep their Python shape, so list/table fields can be filled directly (not just strings).
- **`pin_installed` plugin** (#80) — pin `dependencies` to build-environment versions using templates like `"torch==x.x.*"` (`x` = installed release component, `x+N`, trailing `*`). Implements `dynamic_wheel` (dependencies are Dynamic in the SDist) and `get_requires_for_dynamic_metadata` (the bare package names).
- **`from_file` plugin** (#82) — fill a field from a file: stripped contents for a string field, requirements.txt-style lines for a list field, or a dotted key (`optional-dependencies.test`) for a table field, one entry per key. pip option lines (`-r`, …) are a hard error.
- **Backend collection loops in the loader** (#78) — `loader.py` now provides `get_requires_for_dynamic_metadata(entries)` and `dynamic_wheel_fields(entries)`, so backends get the METADATA 2.2 dynamic set and extra build requirements from one place. Both load providers fresh, keeping `dynamic_wheel` stateless.

### 📚 Docs
- Add a scikit-build-core migration guide (#79).

**Full Changelog**: https://github.com/scikit-build/dynamic-metadata/compare/v0.4.0...v0.5.0
